### PR TITLE
Github action for unity activiation

### DIFF
--- a/blockycraft/activate.yml
+++ b/blockycraft/activate.yml
@@ -1,0 +1,18 @@
+name: Acquire activation file
+on: [push]
+jobs:
+  activation:
+    name: Request manual activation file 🔑
+    runs-on: ubuntu-latest
+    steps:
+      # Request manual activation file
+      - name: Request manual activation file
+        id: getManualLicenseFile
+        uses: webbertakken/unity-request-manual-activation-file@v1.1
+        with:
+          unityVersion: 2019.2.11f1
+      - name: Expose as artifact
+        uses: actions/upload-artifact@v1
+        with:
+          name: ${{ steps.getManualLicenseFile.outputs.filePath }}
+          path: ${{ steps.getManualLicenseFile.outputs.filePath }}


### PR DESCRIPTION
Request a manual file for activation, to work with the github action 'Unity - Builder'.

This action will acquire a Unity personal license, which is required for the build action.