### PR TITLE
Build and deploy to gh-pages with github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,10 +48,9 @@ jobs:
       #     name: Build
       #     path: build
 
-      # - name: Package
-      #   run: |
-      #     ls build/
-      #     ls build/WebGL
+      - name: Package
+        run: |
+          ls
 
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@releases/v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
       #     unityVersion: 2019.3.14f1
 
       - name: Build project
-        uses: webbertakken/unity-builder@v0.10
+        uses: webbertakken/unity-builder@v1.0
         with:
           projectPath: blockycraft/
           unityVersion: 2019.3.14f1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,9 @@ jobs:
         with:
           projectPath: blockycraft/
           unityVersion: 2019.3.14f1
-          targetPlatform: WebGL
+          targetPlatform:
+            - WebGL
+            - StandaloneWindows64
 
       - name: Upload to artifacts
         uses: actions/upload-artifact@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,5 +55,5 @@ jobs:
         # if: github.ref == 'refs/heads/master'
         with:
           ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: gh-pages
+          BRANCH: docs
           FOLDER: docs/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,10 +38,9 @@ jobs:
       - name: Build project
         uses: webbertakken/unity-builder@v1.0
         with:
-          projectPath: blockycraft/
+          projectPath: blockycraft/.
           unityVersion: 2019.3.14f1
-          targetPlatform: StandaloneWindows64
-          # targetPlatform: WebGL
+          targetPlatform: WebGL
             
       - name: Upload to artifacts
         uses: actions/upload-artifact@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,9 +8,6 @@ on:
       - blockycraft/*/*/*
       - blockycraft/*/*/*/*
       - .github/workflows/main.yml
-  push:
-    paths:
-      - .github/workflows/main.yml
 
 env:
   UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
@@ -56,7 +53,7 @@ jobs:
 
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@releases/v3
-        # if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/master'
         with:
           ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Copy binaries for distribution
         run: |
           mkdir -p docs/player
-          cp -r build/blockycraft/WebGL/* docs/player
+          cp -r build/WebGL/blockycraft/* docs/player
 
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@releases/v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,6 +41,7 @@ jobs:
           projectPath: blockycraft/.
           unityVersion: 2019.3.14f1
           targetPlatform: WebGL
+          buildName: blockycraft
             
       - name: Upload to artifacts
         uses: actions/upload-artifact@v1
@@ -51,7 +52,7 @@ jobs:
       - name: Copy binaries for distribution
         run: |
           mkdir -p docs/player
-          cp -r build/WebGL/WebGL/* docs/player
+          cp -r build/blockycraft/WebGL/* docs/player
 
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@releases/v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,25 +21,39 @@ jobs:
         uses: actions/checkout@v2
         with:
           lfs: true
-    
-      - uses: actions/cache@v1.1.0
-        with:
-          path: blockycraft/Library
-          key: blockycraft/Library
 
-      # - name: Run tests
-      #   uses: webbertakken/unity-test-runner@v1.3
+      # - uses: actions/cache@v1.1.0
       #   with:
+      #     path: blockycraft/Library
+      #     key: blockycraft/Library
+
+      # # - name: Run tests
+      # #   uses: webbertakken/unity-test-runner@v1.3
+      # #   with:
+      # #     unityVersion: 2019.3.14f1
+
+      # - name: Build project
+      #   uses: webbertakken/unity-builder@v0.10
+      #   with:
+      #     projectPath: blockycraft/
       #     unityVersion: 2019.3.14f1
+      #     targetPlatform: WebGL
 
-      - name: Build project
-        uses: webbertakken/unity-builder@v0.10
-        with:
-          projectPath: blockycraft/
-          unityVersion: 2019.3.14f1
-          targetPlatform: WebGL 
+      # - name: Upload to artifacts
+      #   uses: actions/upload-artifact@v1
+      #   with:
+      #     name: Build
+      #     path: build
 
-      - uses: actions/upload-artifact@v1
+      # - name: Package
+      #   run: |
+      #     ls build/
+      #     ls build/WebGL
+
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@releases/v3
+        # if: github.ref == 'refs/heads/master'
         with:
-          name: Build
-          path: build
+          ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages
+          FOLDER: docs/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,9 @@ on:
       - blockycraft/*/*/*
       - blockycraft/*/*/*/*
       - .github/workflows/main.yml
+  push:
+    branches:
+      - master
 
 env:
   UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,10 +40,9 @@ jobs:
         with:
           projectPath: blockycraft/
           unityVersion: 2019.3.14f1
-          targetPlatform:
-            - WebGL
-            - StandaloneWindows64
-
+          targetPlatform: StandaloneWindows64
+          # targetPlatform: WebGL
+            
       - name: Upload to artifacts
         uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,9 @@ on:
       - blockycraft/*/*/*
       - blockycraft/*/*/*/*
       - .github/workflows/main.yml
+  push:
+    paths:
+      - .github/workflows/main.yml
 
 env:
   UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,6 +50,7 @@ jobs:
 
       - name: Copy binaries for distribution
         run: |
+          mkdir -p docs/player
           cp -r build/WebGL/WebGL/* docs/player
 
       - name: Deploy 🚀

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,5 +57,5 @@ jobs:
         # if: github.ref == 'refs/heads/master'
         with:
           ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: docs
+          BRANCH: gh-pages
           FOLDER: docs/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,32 +25,32 @@ jobs:
         with:
           lfs: true
 
-      # - uses: actions/cache@v1.1.0
-      #   with:
-      #     path: blockycraft/Library
-      #     key: blockycraft/Library
+      - uses: actions/cache@v1.1.0
+        with:
+          path: blockycraft/Library
+          key: blockycraft/Library
 
-      # # - name: Run tests
-      # #   uses: webbertakken/unity-test-runner@v1.3
-      # #   with:
-      # #     unityVersion: 2019.3.14f1
-
-      # - name: Build project
-      #   uses: webbertakken/unity-builder@v0.10
+      # - name: Run tests
+      #   uses: webbertakken/unity-test-runner@v1.3
       #   with:
-      #     projectPath: blockycraft/
       #     unityVersion: 2019.3.14f1
-      #     targetPlatform: WebGL
 
-      # - name: Upload to artifacts
-      #   uses: actions/upload-artifact@v1
-      #   with:
-      #     name: Build
-      #     path: build
+      - name: Build project
+        uses: webbertakken/unity-builder@v0.10
+        with:
+          projectPath: blockycraft/
+          unityVersion: 2019.3.14f1
+          targetPlatform: WebGL
 
-      - name: Package
+      - name: Upload to artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: Build
+          path: build
+
+      - name: Copy binaries for distribution
         run: |
-          ls
+          cp -r build/WebGL/WebGL/* docs/player
 
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@releases/v3

--- a/blockycraft/ProjectSettings/EditorBuildSettings.asset
+++ b/blockycraft/ProjectSettings/EditorBuildSettings.asset
@@ -4,5 +4,8 @@
 EditorBuildSettings:
   m_ObjectHideFlags: 0
   serializedVersion: 2
-  m_Scenes: []
+  m_Scenes:
+  - enabled: 1
+    path: Assets/Scenes/Blockycraft.unity
+    guid: 9fc0d4010bbf28b4594072e72b8655ab
   m_configObjects: {}

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,3 +3,5 @@
 ## Summary
 
 A stub for the blockycraft webpage.
+
+Validating the pushing.

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,3 +5,9 @@
 A stub for the blockycraft webpage.
 
 Validating the pushing.
+
+## Unity Web Player
+
+You can go to the following to play on the web.
+
+[![Blockycraft - Unity Web Player](logo.png "Blockycraft - Unity Web Player")](www.google.ca)

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,4 +10,4 @@ Validating the pushing.
 
 You can go to the following to play on the web.
 
-[![Blockycraft - Unity Web Player](logo.png "Blockycraft - Unity Web Player")](www.google.ca)
+[![Blockycraft - Unity Web Player](logo.png "Blockycraft - Unity Web Player")](player/index.html)


### PR DESCRIPTION
Compile the unity game and deploy to github pages, accessible using the Unity WebGL player. The license defined for use by CI is that of `personal` rather than `professional`.

The default scene for the project was not set, which meant that CLI-based compilation would just return a black-screen. This ensures that the block-world is shown on startup.

The compiled WebGL application is deployed to blockycraft.jrbeverly.dev, available under `/player`.