### PR TITLE
Support multiple block types in the chunk

### DIFF
--- a/blockycraft/Assets/Behaviours/Chunk.cs
+++ b/blockycraft/Assets/Behaviours/Chunk.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Linq;
 using UnityEngine;
 
 public sealed class Chunk : MonoBehaviour
@@ -9,21 +10,32 @@ public sealed class Chunk : MonoBehaviour
     private BlockType[,] blocks;
     public const int SIZE = 16;
 
+    static BlockType[] ReadBlockTypes() {
+        BlockType[] result;
+        try
+        {
+            result = Resources.LoadAll("BlockTypes/", typeof(BlockType)).Cast<BlockType>().ToArray();
+        }
+        catch (Exception e)
+        {
+            Debug.Log("Proper Method failed with the following exception: ");
+            Debug.Log(e);
+            throw e;
+        }
+        return result;
+    }
+
     void Start()
     {
+        var blockTypes = ReadBlockTypes();
+        
         builder = new VoxelBuilder();
-
-        var grassBlock = Resources.Load<BlockType>("BlockTypes/Grass");
-        if (grassBlock == null)
-        {
-            throw new System.Exception();
-        }
-
         blocks = new BlockType[SIZE, SIZE];
         for (int x = 0; x < blocks.GetLength(0); x++)
             for (int y = 0; y < blocks.GetLength(1); y++)
             {
-                blocks[x, y] = grassBlock;
+                var idx = (y * blocks.GetLength(0) + x) % blockTypes.Length;
+                blocks[x, y] = blockTypes[idx];
             }
 
         var mesh = builder.Build(blocks, Vector3.zero);

--- a/blockycraft/Assets/Resources/BlockTypes/BrickGrey.asset
+++ b/blockycraft/Assets/Resources/BlockTypes/BrickGrey.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4b3dcbb8f276bf4d8e1be3862f9ba27, type: 3}
+  m_Name: BrickGrey
+  m_EditorClassIdentifier: 
+  blockName: Brick (Grey)
+  material: {fileID: 2100000, guid: 7b1043f1574203e419d8073f6a72ed8e, type: 2}
+  left: 0
+  right: 0
+  top: 0
+  bottom: 0
+  front: 0
+  back: 0

--- a/blockycraft/Assets/Resources/BlockTypes/BrickGrey.asset.meta
+++ b/blockycraft/Assets/Resources/BlockTypes/BrickGrey.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: dc20e97b547a35e45899b56038ecb63c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/blockycraft/Assets/Resources/BlockTypes/BrickRed.asset
+++ b/blockycraft/Assets/Resources/BlockTypes/BrickRed.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4b3dcbb8f276bf4d8e1be3862f9ba27, type: 3}
+  m_Name: BrickRed
+  m_EditorClassIdentifier: 
+  blockName: Red Brick
+  material: {fileID: 2100000, guid: 7b1043f1574203e419d8073f6a72ed8e, type: 2}
+  left: 1
+  right: 1
+  top: 1
+  bottom: 1
+  front: 1
+  back: 1

--- a/blockycraft/Assets/Resources/BlockTypes/BrickRed.asset.meta
+++ b/blockycraft/Assets/Resources/BlockTypes/BrickRed.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 223220d754afce74f860481de3149893
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/blockycraft/Assets/Resources/BlockTypes/CottonBlue.asset
+++ b/blockycraft/Assets/Resources/BlockTypes/CottonBlue.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4b3dcbb8f276bf4d8e1be3862f9ba27, type: 3}
+  m_Name: CottonBlue
+  m_EditorClassIdentifier: 
+  blockName: Blue Cotton
+  material: {fileID: 2100000, guid: 7b1043f1574203e419d8073f6a72ed8e, type: 2}
+  left: 5
+  right: 5
+  top: 5
+  bottom: 5
+  front: 5
+  back: 5

--- a/blockycraft/Assets/Resources/BlockTypes/CottonBlue.asset.meta
+++ b/blockycraft/Assets/Resources/BlockTypes/CottonBlue.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6ecba72a1baf4ee4b931a5793e720971
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/blockycraft/Assets/Resources/BlockTypes/CottonGreen.asset
+++ b/blockycraft/Assets/Resources/BlockTypes/CottonGreen.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4b3dcbb8f276bf4d8e1be3862f9ba27, type: 3}
+  m_Name: CottonGreen
+  m_EditorClassIdentifier: 
+  blockName: Green Cotton
+  material: {fileID: 2100000, guid: 7b1043f1574203e419d8073f6a72ed8e, type: 2}
+  left: 6
+  right: 6
+  top: 6
+  bottom: 6
+  front: 6
+  back: 6

--- a/blockycraft/Assets/Resources/BlockTypes/CottonGreen.asset.meta
+++ b/blockycraft/Assets/Resources/BlockTypes/CottonGreen.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c231aa8cad7d4a5409e662e99edc62c9
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/blockycraft/Assets/Resources/BlockTypes/CottonRed.asset
+++ b/blockycraft/Assets/Resources/BlockTypes/CottonRed.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4b3dcbb8f276bf4d8e1be3862f9ba27, type: 3}
+  m_Name: CottonRed
+  m_EditorClassIdentifier: 
+  blockName: Red Cotton
+  material: {fileID: 2100000, guid: 7b1043f1574203e419d8073f6a72ed8e, type: 2}
+  left: 8
+  right: 8
+  top: 8
+  bottom: 8
+  front: 8
+  back: 8

--- a/blockycraft/Assets/Resources/BlockTypes/CottonRed.asset.meta
+++ b/blockycraft/Assets/Resources/BlockTypes/CottonRed.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e23a30b34c61e1e428924a5d8c96ff2c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/blockycraft/Assets/Resources/BlockTypes/CottonTan.asset
+++ b/blockycraft/Assets/Resources/BlockTypes/CottonTan.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4b3dcbb8f276bf4d8e1be3862f9ba27, type: 3}
+  m_Name: CottonTan
+  m_EditorClassIdentifier: 
+  blockName: Tan Cotton
+  material: {fileID: 2100000, guid: 7b1043f1574203e419d8073f6a72ed8e, type: 2}
+  left: 9
+  right: 9
+  top: 9
+  bottom: 9
+  front: 9
+  back: 9

--- a/blockycraft/Assets/Resources/BlockTypes/CottonTan.asset.meta
+++ b/blockycraft/Assets/Resources/BlockTypes/CottonTan.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a298c8811eedb8b418b52077216c0024
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/blockycraft/Assets/Resources/BlockTypes/Dirt.asset
+++ b/blockycraft/Assets/Resources/BlockTypes/Dirt.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4b3dcbb8f276bf4d8e1be3862f9ba27, type: 3}
+  m_Name: Dirt
+  m_EditorClassIdentifier: 
+  blockName: Dirt
+  material: {fileID: 2100000, guid: 7b1043f1574203e419d8073f6a72ed8e, type: 2}
+  left: 10
+  right: 10
+  top: 10
+  bottom: 10
+  front: 10
+  back: 10

--- a/blockycraft/Assets/Resources/BlockTypes/Dirt.asset.meta
+++ b/blockycraft/Assets/Resources/BlockTypes/Dirt.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a8f914cd637083345854577f4a7cfd3c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/blockycraft/Assets/Resources/BlockTypes/Grassy.asset
+++ b/blockycraft/Assets/Resources/BlockTypes/Grassy.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4b3dcbb8f276bf4d8e1be3862f9ba27, type: 3}
+  m_Name: Grassy
+  m_EditorClassIdentifier: 
+  blockName: Grassy
+  material: {fileID: 2100000, guid: 7b1043f1574203e419d8073f6a72ed8e, type: 2}
+  left: 4
+  right: 4
+  top: 4
+  bottom: 10
+  front: 4
+  back: 4

--- a/blockycraft/Assets/Resources/BlockTypes/Grassy.asset.meta
+++ b/blockycraft/Assets/Resources/BlockTypes/Grassy.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 397140feb6d67074f96d2e36d68a210a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Support multiple block types in the 2D plane. This introduces new block types from the existing spritesheet, and uses them as part of the default grid plane.

I expect later this model will need to change to support a kind of 'texture-pack' model to avoid hard-coding the block face types.