### PR TITLE
Convert chunks from 2D plane to 3D plane

### DIFF
--- a/blockycraft/Assets/Behaviours/Chunk.cs
+++ b/blockycraft/Assets/Behaviours/Chunk.cs
@@ -7,10 +7,10 @@ public sealed class Chunk : MonoBehaviour
     public MeshRenderer meshRenderer;
     public MeshFilter meshFilter;
     private VoxelBuilder builder;
-    private BlockType[,] blocks;
-    public const int SIZE = 16;
+    private BlockChunk chunk;
 
-    static BlockType[] ReadBlockTypes() {
+    static BlockType[] ReadBlockTypes()
+    {
         BlockType[] result;
         try
         {
@@ -28,17 +28,17 @@ public sealed class Chunk : MonoBehaviour
     void Start()
     {
         var blockTypes = ReadBlockTypes();
-        
-        builder = new VoxelBuilder();
-        blocks = new BlockType[SIZE, SIZE];
-        for (int x = 0; x < blocks.GetLength(0); x++)
-            for (int y = 0; y < blocks.GetLength(1); y++)
-            {
-                var idx = (y * blocks.GetLength(0) + x) % blockTypes.Length;
-                blocks[x, y] = blockTypes[idx];
-            }
 
-        var mesh = builder.Build(blocks, Vector3.zero);
+        builder = new VoxelBuilder();
+        chunk = new BlockChunk();
+
+        foreach (var block in chunk.ToList())
+        {
+            var idx = (block.Y * chunk.Width + block.X) % blockTypes.Length;
+            chunk.Blocks[block.X, block.Y, block.Z] = blockTypes[idx];
+        }
+
+        var mesh = builder.Build(chunk, Vector3.zero);
         meshFilter.mesh = mesh;
     }
 }

--- a/blockycraft/Assets/Scripts/Geometry/Block.cs
+++ b/blockycraft/Assets/Scripts/Geometry/Block.cs
@@ -1,0 +1,15 @@
+public sealed class Block
+{
+    public BlockType Type { get; set; }
+    public int X { get; set; }
+    public int Y { get; set; }
+    public int Z { get; set; }
+
+    public Block(int x, int y, int z, BlockType type)
+    {
+        X = x;
+        Y = y;
+        Z = z;
+        Type = type;
+    }
+}

--- a/blockycraft/Assets/Scripts/Geometry/Block.cs.meta
+++ b/blockycraft/Assets/Scripts/Geometry/Block.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: be07725e67fa71246a4de8430437dead
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/blockycraft/Assets/Scripts/Geometry/BlockChunk.cs
+++ b/blockycraft/Assets/Scripts/Geometry/BlockChunk.cs
@@ -1,0 +1,26 @@
+﻿using System.Collections.Generic;
+
+public sealed class BlockChunk
+{
+    public const int SIZE = 8;
+
+    private BlockType[,,] blocks;
+
+    public int Width => blocks.GetLength(0);
+    public int Length => blocks.GetLength(1);
+    public int Depth => blocks.GetLength(2);
+    public BlockType[,,] Blocks => blocks;
+
+    public BlockChunk()
+    {
+        blocks = new BlockType[SIZE, SIZE, SIZE];
+    }
+
+    public IEnumerable<Block> ToList()
+    {
+        for (int x = 0; x < Width; x++)
+            for (int y = 0; y < Length; y++)
+                for (int z = 0; z < Depth; z++)
+                    yield return new Block(x, y, z, Blocks[x, y, z]);
+    }
+}

--- a/blockycraft/Assets/Scripts/Geometry/BlockChunk.cs.meta
+++ b/blockycraft/Assets/Scripts/Geometry/BlockChunk.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 39388e331cdfbdf43a50ff4a413fd832
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Converts the 2d voxel plane to a 3d dimensional plane. This commits supports new means of describing blocks in the world, and iterating through the chunk space.

As a note on performance: This implementation is very inefficient in terms of object creation, C# language structs (IEnumerable & multi-dimensional arrays). I'm fine with this for now, as I am trying to narrow down an API that is convenient for world manipulation. The first Blockycraft (& redux version) had significant issues because of how the world accessors behaved. I'd prefer to work in inefficient and malleable, than stiff and performant.