### PR TITLE
Switch chunk initialization to by method

### DIFF
--- a/blockycraft/Assets/Behaviours/Chunk.cs
+++ b/blockycraft/Assets/Behaviours/Chunk.cs
@@ -30,14 +30,7 @@ public sealed class Chunk : MonoBehaviour
         var blockTypes = ReadBlockTypes();
 
         builder = new VoxelBuilder();
-        chunk = new BlockChunk();
-
-        foreach (var block in chunk.ToList())
-        {
-            var idx = (block.Y * chunk.Width + block.X) % blockTypes.Length;
-            chunk.Blocks[block.X, block.Y, block.Z] = blockTypes[idx];
-        }
-
+        chunk = BlockChunk.Assorted(blockTypes);
         var mesh = builder.Build(chunk, Vector3.zero);
         meshFilter.mesh = mesh;
     }

--- a/blockycraft/Assets/Scripts/Geometry/BlockChunk.cs
+++ b/blockycraft/Assets/Scripts/Geometry/BlockChunk.cs
@@ -23,4 +23,22 @@ public sealed class BlockChunk
                 for (int z = 0; z < Depth; z++)
                     yield return new Block(x, y, z, Blocks[x, y, z]);
     }
+
+    public static BlockChunk Default(BlockType type) {
+        var chunk = new BlockChunk();
+        foreach (var block in chunk.ToList())
+            chunk.Blocks[block.X, block.Y, block.Z] = type;
+
+        return chunk;
+    }
+
+    public static BlockChunk Assorted(BlockType[] types) {
+        var chunk = new BlockChunk();
+        foreach (var block in chunk.ToList())
+        {
+            var idx = (block.Y * chunk.Width + block.X) % types.Length;
+            chunk.Blocks[block.X, block.Y, block.Z] = types[idx];
+        }
+        return chunk;
+    }
 }


### PR DESCRIPTION
Support two types of methods for initializing chunks for debugging. One for a single block type, and the other for all the block types in an array.