### PR TITLE
Upload artifacts as release artifacts on tags

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,7 +59,7 @@ jobs:
         id: package-artifact
         run: |
           mkdir -p artifacts/
-          zip -r artifacts/blockycraft-${{ matrix.targetPlatform }}-${{ matrix.unityVersion }}.zip build/${{ matrix.targetPlatform }}/blockycraft/
+          zip -r artifacts/blockycraft-${{ matrix.targetPlatform }}-${{ matrix.unityVersion }}.zip build/${{ matrix.targetPlatform }}/
           echo "::set-output name=path::artifacts/blockycraft-${{ matrix.targetPlatform }}-${{ matrix.unityVersion }}.zip"
 
       - name: Upload to artifacts

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,11 +54,19 @@ jobs:
           targetPlatform: ${{ matrix.targetPlatform }}
           buildName: blockycraft
 
+      # Upload artifacts if we are working with a release
+      - name: Package artifacts for release
+        id: package-artifact
+        run: |
+          mkdir -p artifacts/
+          zip -r artifacts/blockycraft-${{ matrix.targetPlatform }}-${{ matrix.unityVersion }}.zip build/${{ matrix.targetPlatform }}/blockycraft/
+          echo "::set-output name=path::artifacts/blockycraft-${{ matrix.targetPlatform }}-${{ matrix.unityVersion }}.zip"
+
       - name: Upload to artifacts
         uses: actions/upload-artifact@v1
         with:
           name: build-${{ matrix.targetPlatform }}-${{ matrix.unityVersion }}
-          path: build
+          path: ${{ steps.package-artifact.outputs.path }}
 
       # We only need to deploy if working with WeBGL
 
@@ -75,13 +83,6 @@ jobs:
           ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages
           FOLDER: docs/
-
-      # Upload artifacts if we are working with a release
-      - name: Package artifacts for release
-        if: startsWith(github.ref, 'refs/tags/')
-        run: |
-          mkdir -p artifacts/
-          zip -r artifacts/blockycraft-${{ matrix.targetPlatform }}.zip build/${{ matrix.targetPlatform }}/blockycraft/
 
       - name: Create Release
         id: create-release
@@ -103,6 +104,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create-release.outputs.upload_url }}
-          asset_path: artifacts/blockycraft-${{ matrix.targetPlatform }}.zip
+          asset_path: ${{ steps.package-artifact.outputs.path }}
           asset_name: blockycraft-${{ matrix.targetPlatform }}.zip
           asset_content_type: application/zip

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
           unityVersion: ${{ matrix.unityVersion }}
           targetPlatform: ${{ matrix.targetPlatform }}
           buildName: blockycraft
-            
+
       - name: Upload to artifacts
         uses: actions/upload-artifact@v1
         with:
@@ -75,3 +75,34 @@ jobs:
           ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages
           FOLDER: docs/
+
+      # Upload artifacts if we are working with a release
+      - name: Package artifacts for release
+        # if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          mkdir -p artifacts/
+          zip -r artifacts/blockycraft-${{ matrix.targetPlatform }}.zip build/${{ matrix.targetPlatform }}/blockycraft/
+
+     - name: Create Release
+        id: create-release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
+
+      - name: Upload Release Asset
+        id: upload-release-asset
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create-release.outputs.upload_url }}
+          asset_path: artifacts/blockycraft-${{ matrix.targetPlatform }}.zip
+          asset_name: blockycraft-${{ matrix.targetPlatform }}.zip
+          asset_content_type: application/zip

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,12 +78,12 @@ jobs:
 
       # Upload artifacts if we are working with a release
       - name: Package artifacts for release
-        # if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/')
         run: |
           mkdir -p artifacts/
           zip -r artifacts/blockycraft-${{ matrix.targetPlatform }}.zip build/${{ matrix.targetPlatform }}/blockycraft/
 
-     - name: Create Release
+      - name: Create Release
         id: create-release
         if: startsWith(github.ref, 'refs/tags/')
         uses: actions/create-release@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,18 +55,12 @@ jobs:
           buildName: blockycraft
 
       # Upload artifacts if we are working with a release
-      - name: Package artifacts for release
-        id: package-artifact
-        run: |
-          mkdir -p artifacts/
-          zip -r artifacts/blockycraft-${{ matrix.targetPlatform }}-${{ matrix.unityVersion }}.zip build/${{ matrix.targetPlatform }}/
-          echo "::set-output name=path::artifacts/blockycraft-${{ matrix.targetPlatform }}-${{ matrix.unityVersion }}.zip"
 
       - name: Upload to artifacts
         uses: actions/upload-artifact@v1
         with:
           name: build-${{ matrix.targetPlatform }}-${{ matrix.unityVersion }}
-          path: ${{ steps.package-artifact.outputs.path }}
+          path: build/${{ matrix.targetPlatform }}/
 
       # We only need to deploy if working with WeBGL
 
@@ -83,6 +77,14 @@ jobs:
           ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages
           FOLDER: docs/
+
+      - name: Package artifacts for release
+        id: package-artifact
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          mkdir -p artifacts/
+          zip -r artifacts/blockycraft-${{ matrix.targetPlatform }}-${{ matrix.unityVersion }}.zip build/${{ matrix.targetPlatform }}/
+          echo "::set-output name=path::artifacts/blockycraft-${{ matrix.targetPlatform }}-${{ matrix.unityVersion }}.zip"
 
       - name: Create Release
         id: create-release


### PR DESCRIPTION
When creating a release, all the build artifacts should be uploaded as zip files. These will map to the support target platforms, and be uploaded by each compilation pipeline.