### PR TITLE
Allow the compilation workflow to run on tags

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,8 @@ on:
   push:
     branches:
       - master
+    tags:
+      - v*
 
 env:
   UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}


### PR DESCRIPTION
The compilation workflow does not run on tag creations.

This resolves the issue where creating a release does not result in the artifacts being uploaded.