### PR TITLE
Support running on tag created

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,6 +56,7 @@ jobs:
           unityVersion: ${{ matrix.unityVersion }}
           targetPlatform: ${{ matrix.targetPlatform }}
           buildName: blockycraft
+          versioning: Semantic
 
       # Upload artifacts if we are working with a release
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,8 +11,9 @@ on:
   push:
     branches:
       - master
+  create:
     tags:
-      - v*
+      - "*"
 
 env:
   UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}


### PR DESCRIPTION
Instead of running on push of a tag, switch to on create of a tag. Remove the requirement for `v` as prefix.