### PR TITLE
Implement a rough outline of an asset-driven biome model

### DIFF
--- a/blockycraft/Assets/Behaviours/Chunk.cs
+++ b/blockycraft/Assets/Behaviours/Chunk.cs
@@ -29,12 +29,11 @@ public sealed class Chunk
         meshFilter.mesh = mesh;
     }
 
-    public static Chunk Create(BlockType[] blockTypes, Material material, int x, int z, GameObject parent)
+    public static Chunk Create(BlockChunk blocks, Material material, int x, int z, GameObject parent)
     {
-        // Temporary method responsible for creating chunks
         var chunk = new Chunk
         {
-            Blocks = BlockChunk.Assorted(blockTypes),
+            Blocks = blocks,
             Voxel = material,
             X = x,
             Z = z,

--- a/blockycraft/Assets/Behaviours/World.cs
+++ b/blockycraft/Assets/Behaviours/World.cs
@@ -24,15 +24,33 @@ public sealed class World : MonoBehaviour
         return result;
     }
 
+    static Biome ReadFlatBiome()
+    {
+        Biome result;
+        try
+        {
+            result = (Biome)Resources.Load("Biomes/Flat", typeof(Biome));
+        }
+        catch (Exception e)
+        {
+            Debug.Log("Proper Method failed with the following exception: ");
+            Debug.Log(e);
+            throw e;
+        }
+        return result;
+    }
+
     void Start()
     {
         var blockTypes = ReadBlockTypes();
+        var biome = ReadFlatBiome();
         
         for (int x = 0; x < chunks.GetLength(0); x++)
         {
             for (int z = 0; z < chunks.GetLength(1); z++)
             {
-                chunks[x, z] = Chunk.Create(blockTypes, material, x, z, gameObject); ;
+                var blocks = WorldGenerator.Generate(biome);
+                chunks[x, z] = Chunk.Create(blocks, material, x, z, gameObject); ;
             }
         }
     }

--- a/blockycraft/Assets/Resources/Biomes.meta
+++ b/blockycraft/Assets/Resources/Biomes.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 456ff9d46f9c4784881b7d406ebdb806
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/blockycraft/Assets/Resources/Biomes/Flat.asset
+++ b/blockycraft/Assets/Resources/Biomes/Flat.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 36b36aab1c7472f45b1d7784fb1bff61, type: 3}
+  m_Name: Flat
+  m_EditorClassIdentifier: 
+  Name: Flat Biome
+  GroundHeight: 0
+  Height: 0
+  BlockTypes: []

--- a/blockycraft/Assets/Resources/Biomes/Flat.asset.meta
+++ b/blockycraft/Assets/Resources/Biomes/Flat.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 78a2964576f07ae43a12ebea1d2da8c6
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/blockycraft/Assets/Scripts/Biome.meta
+++ b/blockycraft/Assets/Scripts/Biome.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6612037f8b02c9843a1e94299c0d1345
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/blockycraft/Assets/Scripts/Biome/Biome.cs
+++ b/blockycraft/Assets/Scripts/Biome/Biome.cs
@@ -1,0 +1,22 @@
+﻿using UnityEngine;
+using System.Collections.Generic;
+
+[CreateAssetMenu(fileName = "Biome", menuName = "Blockycraft/Biome")]
+public sealed class Biome : ScriptableObject
+{
+    [Header("Descriptors")]
+    public string Name;
+
+    [Header("Properties")]
+    public int GroundHeight;
+    public int Height;
+
+    [Header("Composition")]
+    public List<BiomeBlocks> Blocks;
+
+    public Biome() {
+        GroundHeight = 1;
+        Height = byte.MaxValue;
+        Blocks = new List<BiomeBlocks>();
+    }
+}

--- a/blockycraft/Assets/Scripts/Biome/Biome.cs.meta
+++ b/blockycraft/Assets/Scripts/Biome/Biome.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 36b36aab1c7472f45b1d7784fb1bff61
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/blockycraft/Assets/Scripts/Biome/BiomeBlocks.cs
+++ b/blockycraft/Assets/Scripts/Biome/BiomeBlocks.cs
@@ -1,0 +1,15 @@
+[System.Serializable]
+public sealed class BiomeBlocks
+{
+    public BlockType Type;
+    public int Minimum;
+    public int Maximum;
+    public float Threshold;
+
+    public BiomeBlocks() {
+        Minimum = 1;
+        Maximum = byte.MaxValue;
+        Threshold = 1.0f;
+    }
+}
+

--- a/blockycraft/Assets/Scripts/Biome/BiomeBlocks.cs.meta
+++ b/blockycraft/Assets/Scripts/Biome/BiomeBlocks.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2e97dfa9fed1b3c439428361ad64ddf8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/blockycraft/Assets/Scripts/Biome/WorldGenerator.cs
+++ b/blockycraft/Assets/Scripts/Biome/WorldGenerator.cs
@@ -1,0 +1,32 @@
+public sealed class WorldGenerator
+{
+    public static BlockChunk Generate(Biome biome)
+    {
+        var chunk = new BlockChunk();
+        foreach (var block in chunk.ToList()) {
+            var idx = block.Y % biome.Blocks.Count;
+            chunk.Blocks[block.X, block.Y, block.Z] = biome.Blocks[idx].Type;
+        }
+        return chunk;
+    }
+
+    public static BlockChunk Default(BlockType type)
+    {
+        var chunk = new BlockChunk();
+        foreach (var block in chunk.ToList())
+            chunk.Blocks[block.X, block.Y, block.Z] = type;
+
+        return chunk;
+    }
+
+    public static BlockChunk Assorted(BlockType[] types)
+    {
+        var chunk = new BlockChunk();
+        foreach (var block in chunk.ToList())
+        {
+            var idx = (block.Y * chunk.Width + block.X) % types.Length;
+            chunk.Blocks[block.X, block.Y, block.Z] = types[idx];
+        }
+        return chunk;
+    }
+}

--- a/blockycraft/Assets/Scripts/Biome/WorldGenerator.cs.meta
+++ b/blockycraft/Assets/Scripts/Biome/WorldGenerator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5e8ae90806f237d49810dd077ad7b133
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/blockycraft/Assets/Scripts/Geometry/BlockChunk.cs
+++ b/blockycraft/Assets/Scripts/Geometry/BlockChunk.cs
@@ -23,22 +23,4 @@ public sealed class BlockChunk
                 for (int z = 0; z < Depth; z++)
                     yield return new Block(x, y, z, Blocks[x, y, z]);
     }
-
-    public static BlockChunk Default(BlockType type) {
-        var chunk = new BlockChunk();
-        foreach (var block in chunk.ToList())
-            chunk.Blocks[block.X, block.Y, block.Z] = type;
-
-        return chunk;
-    }
-
-    public static BlockChunk Assorted(BlockType[] types) {
-        var chunk = new BlockChunk();
-        foreach (var block in chunk.ToList())
-        {
-            var idx = (block.Y * chunk.Width + block.X) % types.Length;
-            chunk.Blocks[block.X, block.Y, block.Z] = types[idx];
-        }
-        return chunk;
-    }
 }


### PR DESCRIPTION
Replace the assorted block chunks with the early stages of a biome-driven model of world generation.

Biomes are composed of a set of blocks that can exist in that world, a generator that defines how those blocks are placed in the world, and a series of parameters for how the 'World' is perceived. 

This starts the basic outline of the world with biomes defined as assets. The code responsible for the flat world generation will later be split into its own type of 'Generator', responsible for laying the blocks in the world.

Generation will follow the model of `Noise(parameters) -> Transform -> Conditions` which hopefully can support a lot of diversity with shared 'Generator' classes.