### PR TITLE
Missing block types in flat biome for baseline

### DIFF
--- a/blockycraft/Assets/Behaviours/World.cs
+++ b/blockycraft/Assets/Behaviours/World.cs
@@ -50,7 +50,7 @@ public sealed class World : MonoBehaviour
             for (int z = 0; z < chunks.GetLength(1); z++)
             {
                 var blocks = WorldGenerator.Generate(biome);
-                chunks[x, z] = Chunk.Create(blocks, material, x, z, gameObject); ;
+                chunks[x, z] = Chunk.Create(blocks, material, x, z, gameObject);
             }
         }
     }

--- a/blockycraft/Assets/Resources/Biomes/Flat.asset
+++ b/blockycraft/Assets/Resources/Biomes/Flat.asset
@@ -15,4 +15,12 @@ MonoBehaviour:
   Name: Flat Biome
   GroundHeight: 0
   Height: 0
-  BlockTypes: []
+  Blocks:
+  - Type: {fileID: 11400000, guid: a8f914cd637083345854577f4a7cfd3c, type: 2}
+    Minimum: 0
+    Maximum: 0
+    Threshold: 0
+  - Type: {fileID: 11400000, guid: 28e59d219862508419a9db71331f0f31, type: 2}
+    Minimum: 0
+    Maximum: 0
+    Threshold: 0


### PR DESCRIPTION
The block types for the flat biome were not included in cc79046754a4f811a295a56c52fad74214f24b01.

This resulted in nothing being rendered, as the flat model `Y % Count` is not viable when `Count = 0`.