### PR TITLE
Move GitHub Pages deploy to separate job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,6 @@ jobs:
           unityVersion: ${{ matrix.unityVersion }}
           targetPlatform: ${{ matrix.targetPlatform }}
           buildName: blockycraft
-          versioning: Semantic
 
       # Upload artifacts if we are working with a release
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,10 +26,10 @@ jobs:
         unityVersion:
           - 2019.3.14f1
         targetPlatform:
-          - StandaloneOSX
-          - StandaloneWindows
-          - StandaloneWindows64
-          - StandaloneLinux64
+          # - StandaloneOSX
+          # - StandaloneWindows
+          # - StandaloneWindows64
+          # - StandaloneLinux64
           - WebGL
     runs-on: ubuntu-latest
     steps:
@@ -70,15 +70,21 @@ jobs:
     needs: [ build ]
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          lfs: true
+
       - name: Download WebGL from service
         uses: actions/download-artifact@v2
         with:
           name: build-WebGL-2019.3.14f1
-          path: docs/player
+          path: artifacts
 
       - name: Prepare WebGL player for GitHub Pages
         run: |
-          ls docs/player
+          mv artifacts/blockycraft docs/play
+          ls docs/play
 
       # - name: Deploy 🚀
       #   uses: JamesIves/github-pages-deploy-action@releases/v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,11 +43,6 @@ jobs:
           path: blockycraft/Library
           key: blockycraft/Library
 
-      # - name: Run tests
-      #   uses: webbertakken/unity-test-runner@v1.3
-      #   with:
-      #     unityVersion: 2019.3.14f1
-
       - name: Build project
         uses: webbertakken/unity-builder@v1.0
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,6 +68,7 @@ jobs:
   ghpages:
     # if: github.ref == 'refs/heads/master'
     name: Deploy to GitHub Pages
+    needs: [ build ]
     runs-on: ubuntu-latest
     steps:
       - name: Download WebGL from service

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,50 +65,24 @@ jobs:
           name: build-${{ matrix.targetPlatform }}-${{ matrix.unityVersion }}
           path: build/${{ matrix.targetPlatform }}/
 
-      # We only need to deploy if working with WeBGL
+  ghpages:
+    # if: github.ref == 'refs/heads/master'
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download WebGL from service
+        uses: actions/download-artifact@v2
+        with:
+          name: build-WebGL-2019.3.14f1
+          path: docs/player
 
-      - name: Copy binaries for distribution
-        if: matrix.targetPlatform == 'WebGL'
+      - name: Prepare WebGL player for GitHub Pages
         run: |
-          mkdir -p docs/player
-          cp -r build/WebGL/blockycraft/* docs/player
+          ls docs/player
 
-      - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@releases/v3
-        if: github.ref == 'refs/heads/master' && matrix.targetPlatform == 'WebGL'
-        with:
-          ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: gh-pages
-          FOLDER: docs/
-
-      - name: Package artifacts for release
-        id: package-artifact
-        if: startsWith(github.ref, 'refs/tags/')
-        run: |
-          mkdir -p artifacts/
-          zip -r artifacts/blockycraft-${{ matrix.targetPlatform }}-${{ matrix.unityVersion }}.zip build/${{ matrix.targetPlatform }}/
-          echo "::set-output name=path::artifacts/blockycraft-${{ matrix.targetPlatform }}-${{ matrix.unityVersion }}.zip"
-
-      - name: Create Release
-        id: create-release
-        if: startsWith(github.ref, 'refs/tags/')
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          draft: false
-          prerelease: false
-
-      - name: Upload Release Asset
-        id: upload-release-asset
-        if: startsWith(github.ref, 'refs/tags/')
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create-release.outputs.upload_url }}
-          asset_path: ${{ steps.package-artifact.outputs.path }}
-          asset_name: blockycraft-${{ matrix.targetPlatform }}.zip
-          asset_content_type: application/zip
+      # - name: Deploy 🚀
+      #   uses: JamesIves/github-pages-deploy-action@releases/v3
+      #   with:
+      #     ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #     BRANCH: gh-pages
+      #     FOLDER: docs/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,10 +26,10 @@ jobs:
         unityVersion:
           - 2019.3.14f1
         targetPlatform:
-          # - StandaloneOSX
-          # - StandaloneWindows
-          # - StandaloneWindows64
-          # - StandaloneLinux64
+          - StandaloneOSX
+          - StandaloneWindows
+          - StandaloneWindows64
+          - StandaloneLinux64
           - WebGL
     runs-on: ubuntu-latest
     steps:
@@ -56,8 +56,6 @@ jobs:
           targetPlatform: ${{ matrix.targetPlatform }}
           buildName: blockycraft
 
-      # Upload artifacts if we are working with a release
-
       - name: Upload to artifacts
         uses: actions/upload-artifact@v1
         with:
@@ -65,9 +63,9 @@ jobs:
           path: build/${{ matrix.targetPlatform }}/
 
   ghpages:
-    # if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/master'
     name: Deploy to GitHub Pages
-    needs: [ build ]
+    needs: [build]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -75,20 +73,20 @@ jobs:
         with:
           lfs: true
 
-      - name: Download WebGL from service
+      - name: Download WebGL build
         uses: actions/download-artifact@v2
         with:
           name: build-WebGL-2019.3.14f1
           path: artifacts
 
-      - name: Prepare WebGL player for GitHub Pages
+      - name: Prepare WebGL player
         run: |
           mv artifacts/blockycraft docs/play
           ls docs/play
 
-      # - name: Deploy 🚀
-      #   uses: JamesIves/github-pages-deploy-action@releases/v3
-      #   with:
-      #     ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #     BRANCH: gh-pages
-      #     FOLDER: docs/
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@releases/v3
+        with:
+          ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages
+          FOLDER: docs/

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,4 +10,4 @@ Validating the pushing.
 
 You can go to the following to play on the web.
 
-[![Blockycraft - Unity Web Player](logo.png "Blockycraft - Unity Web Player")](player/index.html)
+[![Blockycraft - Unity Web Player](logo.png "Blockycraft - Unity Web Player")](play/)


### PR DESCRIPTION
Move deploying to `gh-pages` into its own job, that will execute after the build process has completed.

The build job is only responsible for deploying to `gh-pages` when running on `master` and `WebGL`. This adds overhead when working with other target platforms, as many of the jobs related to `gh-pages` or releases are not relevant.
