### PR TITLE
Support a 3D Iterator model replacing block enumeration

### DIFF
--- a/blockycraft/Assets/Behaviours/World.cs
+++ b/blockycraft/Assets/Behaviours/World.cs
@@ -42,7 +42,6 @@ public sealed class World : MonoBehaviour
 
     void Start()
     {
-        var blockTypes = ReadBlockTypes();
         var biome = ReadFlatBiome();
         
         for (int x = 0; x < chunks.GetLength(0); x++)

--- a/blockycraft/Assets/Scripts/Biome/WorldGenerator.cs
+++ b/blockycraft/Assets/Scripts/Biome/WorldGenerator.cs
@@ -3,9 +3,10 @@ public sealed class WorldGenerator
     public static BlockChunk Generate(Biome biome)
     {
         var chunk = new BlockChunk();
-        foreach (var block in chunk.ToList()) {
-            var idx = block.Y % biome.Blocks.Count;
-            chunk.Blocks[block.X, block.Y, block.Z] = biome.Blocks[idx].Type;
+        var iterator = chunk.GetIterator();
+        foreach (var block in iterator) {
+            var idx = (int)(block.y % biome.Blocks.Count);
+            chunk.Blocks[(int)block.x, (int)block.y, (int)block.z] = biome.Blocks[idx].Type;
         }
         return chunk;
     }
@@ -13,8 +14,9 @@ public sealed class WorldGenerator
     public static BlockChunk Default(BlockType type)
     {
         var chunk = new BlockChunk();
-        foreach (var block in chunk.ToList())
-            chunk.Blocks[block.X, block.Y, block.Z] = type;
+        var iterator = chunk.GetIterator();
+        foreach (var block in iterator)
+            chunk.Blocks[(int)block.x, (int)block.y, (int)block.z] = type;
 
         return chunk;
     }
@@ -22,10 +24,11 @@ public sealed class WorldGenerator
     public static BlockChunk Assorted(BlockType[] types)
     {
         var chunk = new BlockChunk();
-        foreach (var block in chunk.ToList())
+        var iterator = chunk.GetIterator();
+        foreach (var block in iterator)
         {
-            var idx = (block.Y * chunk.Width + block.X) % types.Length;
-            chunk.Blocks[block.X, block.Y, block.Z] = types[idx];
+            var idx = (int) ((block.y * chunk.Width + block.x) % types.Length);
+            chunk.Blocks[(int)block.x, (int)block.y, (int)block.z] = types[idx];
         }
         return chunk;
     }

--- a/blockycraft/Assets/Scripts/Biome/WorldGenerator.cs
+++ b/blockycraft/Assets/Scripts/Biome/WorldGenerator.cs
@@ -4,9 +4,10 @@ public sealed class WorldGenerator
     {
         var chunk = new BlockChunk();
         var iterator = chunk.GetIterator();
-        foreach (var block in iterator) {
-            var idx = (int)(block.y % biome.Blocks.Count);
-            chunk.Blocks[(int)block.x, (int)block.y, (int)block.z] = biome.Blocks[idx].Type;
+        foreach (var (x, y, z) in iterator)
+        {
+            var idx = y % biome.Blocks.Count;
+            chunk.Blocks[x, y, z] = biome.Blocks[idx].Type;
         }
         return chunk;
     }
@@ -15,8 +16,8 @@ public sealed class WorldGenerator
     {
         var chunk = new BlockChunk();
         var iterator = chunk.GetIterator();
-        foreach (var block in iterator)
-            chunk.Blocks[(int)block.x, (int)block.y, (int)block.z] = type;
+        foreach (var (x, y, z) in iterator)
+            chunk.Blocks[x, y, z] = type;
 
         return chunk;
     }
@@ -25,10 +26,10 @@ public sealed class WorldGenerator
     {
         var chunk = new BlockChunk();
         var iterator = chunk.GetIterator();
-        foreach (var block in iterator)
+        foreach (var (x, y, z) in iterator)
         {
-            var idx = (int) ((block.y * chunk.Width + block.x) % types.Length);
-            chunk.Blocks[(int)block.x, (int)block.y, (int)block.z] = types[idx];
+            var idx = (y * chunk.Width + x) % types.Length;
+            chunk.Blocks[x, y, z] = types[idx];
         }
         return chunk;
     }

--- a/blockycraft/Assets/Scripts/Geometry/BlockChunk.cs
+++ b/blockycraft/Assets/Scripts/Geometry/BlockChunk.cs
@@ -3,24 +3,18 @@
 public sealed class BlockChunk
 {
     public const int SIZE = 8;
-
-    private BlockType[,,] blocks;
-
-    public int Width => blocks.GetLength(0);
-    public int Length => blocks.GetLength(1);
-    public int Depth => blocks.GetLength(2);
-    public BlockType[,,] Blocks => blocks;
+    public int Width => Blocks.GetLength(0);
+    public int Length => Blocks.GetLength(1);
+    public int Depth => Blocks.GetLength(2);
+    public BlockType[,,] Blocks { get; }
 
     public BlockChunk()
     {
-        blocks = new BlockType[SIZE, SIZE, SIZE];
+        Blocks = new BlockType[SIZE, SIZE, SIZE];
     }
 
-    public IEnumerable<Block> ToList()
+    public Iterator3D GetIterator()
     {
-        for (int x = 0; x < Width; x++)
-            for (int y = 0; y < Length; y++)
-                for (int z = 0; z < Depth; z++)
-                    yield return new Block(x, y, z, Blocks[x, y, z]);
+        return new Iterator3D(Width, Length, Depth);
     }
 }

--- a/blockycraft/Assets/Scripts/Geometry/VoxelBuilder.cs
+++ b/blockycraft/Assets/Scripts/Geometry/VoxelBuilder.cs
@@ -67,16 +67,19 @@ public sealed class VoxelBuilder
         var vertices = new List<Vector3>();
         var triangles = new List<int>();
         var uvs = new List<Vector2>();
+        var iterator = blocks.GetIterator();
 
-        foreach (var block in blocks.ToList())
+        foreach (var block in iterator)
         {
-            var offset = block.X * Vector3.right + block.Z * Vector3.forward + block.Y * Vector3.up;
+            var type = blocks.Blocks[(int)block.x, (int)block.y, (int)block.z];
+
+            var offset = block.x * Vector3.right + block.z * Vector3.forward + block.y * Vector3.up;
             for (int face = 0; face < Voxel.NumberOfFaces; face++)
             {
                 for (int vert = 0; vert < Voxel.VerticesInFace; vert++)
                     vertices.Add(position + offset + Voxel.Vertices[Voxel.Tris[face, vert]]);
 
-                var uv = ComputeUV(block.Type, face);
+                var uv = ComputeUV(type, face);
                 uvs.Add(uv);
                 uvs.Add(new Vector2(uv.x, uv.y + GridUVFactor));
                 uvs.Add(new Vector2(uv.x + GridUVFactor, uv.y));

--- a/blockycraft/Assets/Scripts/Geometry/VoxelBuilder.cs
+++ b/blockycraft/Assets/Scripts/Geometry/VoxelBuilder.cs
@@ -1,11 +1,8 @@
-using System;
 using System.Collections.Generic;
-using UnityEditor;
 using UnityEngine;
 
 public sealed class VoxelBuilder
 {
-    //TODO: Use a reference to the material itself (or some custom object)
     public static readonly int GridSize = 8;
     public static float GridUVFactor { get { return 1f / (float)GridSize; }}
 
@@ -18,12 +15,6 @@ public sealed class VoxelBuilder
             x * GridUVFactor, 
             1f - (y + 1) * GridUVFactor
         );
-    }
-
-    private IEnumerable<(int, int)> ListBlocks(BlockType[,] blocks) {
-        for (int x = 0; x < blocks.GetLength(0); x++)
-            for (int y = 0; y < blocks.GetLength(1); y++)
-                yield return (x, y);
     }
 
     public Mesh Build(BlockType block, Vector3 position)
@@ -69,11 +60,11 @@ public sealed class VoxelBuilder
         var uvs = new List<Vector2>();
         var iterator = blocks.GetIterator();
 
-        foreach (var block in iterator)
+        foreach (var (x, y, z) in iterator)
         {
-            var type = blocks.Blocks[(int)block.x, (int)block.y, (int)block.z];
+            var type = blocks.Blocks[x, y, z];
 
-            var offset = block.x * Vector3.right + block.z * Vector3.forward + block.y * Vector3.up;
+            var offset = x * Vector3.right + z * Vector3.forward + y * Vector3.up;
             for (int face = 0; face < Voxel.NumberOfFaces; face++)
             {
                 for (int vert = 0; vert < Voxel.VerticesInFace; vert++)

--- a/blockycraft/Assets/Scripts/Iterator3D.cs
+++ b/blockycraft/Assets/Scripts/Iterator3D.cs
@@ -1,8 +1,7 @@
-using UnityEngine;
 using System.Collections;
 using System.Collections.Generic;
 
-public sealed class Iterator3D : IEnumerable<Vector3>
+public sealed class Iterator3D : IEnumerable<(int x, int y, int z)>
 {
     public int Width { get; }
     public int Length { get; }
@@ -17,12 +16,12 @@ public sealed class Iterator3D : IEnumerable<Vector3>
         Depth = depth;
     }
 
-    public IEnumerator<Vector3> GetEnumerator()
+    public IEnumerator<(int x, int y, int z)> GetEnumerator()
     {
         for (int x = 0; x < Width; x++)
             for (int y = 0; y < Length; y++)
                 for (int z = 0; z < Depth; z++)
-                    yield return new Vector3(x, y, z);
+                    yield return (x, y, z);
     }
 
     IEnumerator IEnumerable.GetEnumerator()

--- a/blockycraft/Assets/Scripts/Iterator3D.cs
+++ b/blockycraft/Assets/Scripts/Iterator3D.cs
@@ -1,0 +1,32 @@
+using UnityEngine;
+using System.Collections;
+using System.Collections.Generic;
+
+public sealed class Iterator3D : IEnumerable<Vector3>
+{
+    public int Width { get; }
+    public int Length { get; }
+    public int Depth { get; }
+
+    public Iterator3D(int size) : this(size, size, size) { }
+
+    public Iterator3D(int width, int length, int depth)
+    {
+        Width = width;
+        Length = length;
+        Depth = depth;
+    }
+
+    public IEnumerator<Vector3> GetEnumerator()
+    {
+        for (int x = 0; x < Width; x++)
+            for (int y = 0; y < Length; y++)
+                for (int z = 0; z < Depth; z++)
+                    yield return new Vector3(x, y, z);
+    }
+
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return GetEnumerator();
+    }
+}

--- a/blockycraft/Assets/Scripts/Iterator3D.cs.meta
+++ b/blockycraft/Assets/Scripts/Iterator3D.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bb023937dc9652d40b669eb2d7131b24
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Support an iterator capable of simplifying iterator over three dimensions into a single iteration loop.

This keeps with the cleanliness of the previous approach, while removing the unnecssary bloat that the `Block` per loop introduced. Both of these approaches create unnecessary allocations through types (previously `Block`, this by `anonymous type`). However `Iterator3D` removes locking the concept of Iterator to Blocks, and replaced it with a generic Iterator.

A `fast` iterator may be considered using a model like `.HasNext(), .Next(), .Peek()`, but in terms of performance considerations I do not believe they will be necessary for the project.