### PR TITLE
Support uploading the compiled artifacts to releases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,7 +88,7 @@ jobs:
 
   release:
       name: Create Github Release
-      if: contains(github.ref, 'tags/v')
+      if: contains(github.ref, 'tags/')
       needs: [build]
       runs-on: ubuntu-latest
       steps:
@@ -113,7 +113,7 @@ jobs:
           path: release_url.txt
 
   publish:
-    if: contains(github.ref, 'tags/v')
+    if: contains(github.ref, 'tags/')
     needs: [build, release]
     strategy:
       fail-fast: false
@@ -152,8 +152,9 @@ jobs:
       env:
         TAG_REF_NAME: ${{ github.ref }}
         REPOSITORY_NAME: ${{ github.repository }}
+
     - name: Upload Release Asset
-      id: upload-release-asset 
+      id: upload-release-asset
       uses: actions/upload-release-asset@v1.0.1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,3 +85,80 @@ jobs:
           ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages
           FOLDER: docs/
+
+ release:
+    name: Create Github Release
+    if: contains(github.ref, 'tags/v')
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1.0.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Release ${{ github.ref }}
+        draft: false
+        prerelease: false
+
+    - name: Output Release URL File
+      run: echo "${{ steps.create_release.outputs.upload_url }}" > release_url.txt
+
+    - name: Save Release URL File for publish
+      uses: actions/upload-artifact@v1
+      with:
+        name: release_url
+        path: release_url.txt
+
+  publish:
+    if: contains(github.ref, 'tags/v')
+    needs: [build, release]
+    strategy:
+      fail-fast: false
+      matrix:
+        unityVersion:
+          - 2019.3.14f1
+        targetPlatform:
+          - StandaloneOSX
+          - StandaloneWindows
+          - StandaloneWindows64
+          - StandaloneLinux64
+          - WebGL
+    runs-on: ubuntu-latest
+    steps:
+    - name: Load Release URL File from release job
+      uses: actions/download-artifact@v1
+      with:
+        name: release_url
+
+    - name: Download artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: build-${{ matrix.targetPlatform }}-${{ matrix.unityVersion }}
+        path: artifacts
+
+    - name: Package artifact for release
+      run: |
+        zip -r ${{ matrix.targetPlatform }}.zip ./artifacts/
+
+    - name: Get Release File Name & Upload URL
+      id: get_release_info
+      run: |
+        echo ::set-output name=file_name::${REPOSITORY_NAME##*/}-${TAG_REF_NAME##*/v}
+        value=`cat release_url/release_url.txt`
+        echo ::set-output name=upload_url::$value
+      env:
+        TAG_REF_NAME: ${{ github.ref }}
+        REPOSITORY_NAME: ${{ github.repository }}
+    - name: Upload Release Asset
+      id: upload-release-asset 
+      uses: actions/upload-release-asset@v1.0.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.get_release_info.outputs.upload_url }}
+        asset_path: ./${{ matrix.targetPlatform }}.zip
+        asset_name: ${{ steps.get_release_info.outputs.file_name }}-${{ matrix.targetPlatform }}.zip
+        asset_content_type: application/zip

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -112,53 +112,53 @@ jobs:
           name: release_url
           path: release_url.txt
 
-    publish:
-      if: contains(github.ref, 'tags/v')
-      needs: [build, release]
-      strategy:
-        fail-fast: false
-        matrix:
-          unityVersion:
-            - 2019.3.14f1
-          targetPlatform:
-            - StandaloneOSX
-            - StandaloneWindows
-            - StandaloneWindows64
-            - StandaloneLinux64
-            - WebGL
-      runs-on: ubuntu-latest
-      steps:
-      - name: Load Release URL File from release job
-        uses: actions/download-artifact@v1
-        with:
-          name: release_url
+  publish:
+    if: contains(github.ref, 'tags/v')
+    needs: [build, release]
+    strategy:
+      fail-fast: false
+      matrix:
+        unityVersion:
+          - 2019.3.14f1
+        targetPlatform:
+          - StandaloneOSX
+          - StandaloneWindows
+          - StandaloneWindows64
+          - StandaloneLinux64
+          - WebGL
+    runs-on: ubuntu-latest
+    steps:
+    - name: Load Release URL File from release job
+      uses: actions/download-artifact@v1
+      with:
+        name: release_url
 
-      - name: Download artifact
-        uses: actions/download-artifact@v2
-        with:
-          name: build-${{ matrix.targetPlatform }}-${{ matrix.unityVersion }}
-          path: artifacts
+    - name: Download artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: build-${{ matrix.targetPlatform }}-${{ matrix.unityVersion }}
+        path: artifacts
 
-      - name: Package artifact for release
-        run: |
-          zip -r ${{ matrix.targetPlatform }}.zip ./artifacts/
+    - name: Package artifact for release
+      run: |
+        zip -r ${{ matrix.targetPlatform }}.zip ./artifacts/
 
-      - name: Get Release File Name & Upload URL
-        id: get_release_info
-        run: |
-          echo ::set-output name=file_name::${REPOSITORY_NAME##*/}-${TAG_REF_NAME##*/v}
-          value=`cat release_url/release_url.txt`
-          echo ::set-output name=upload_url::$value
-        env:
-          TAG_REF_NAME: ${{ github.ref }}
-          REPOSITORY_NAME: ${{ github.repository }}
-      - name: Upload Release Asset
-        id: upload-release-asset 
-        uses: actions/upload-release-asset@v1.0.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.get_release_info.outputs.upload_url }}
-          asset_path: ./${{ matrix.targetPlatform }}.zip
-          asset_name: ${{ steps.get_release_info.outputs.file_name }}-${{ matrix.targetPlatform }}.zip
-          asset_content_type: application/zip
+    - name: Get Release File Name & Upload URL
+      id: get_release_info
+      run: |
+        echo ::set-output name=file_name::${REPOSITORY_NAME##*/}-${TAG_REF_NAME##*/v}
+        value=`cat release_url/release_url.txt`
+        echo ::set-output name=upload_url::$value
+      env:
+        TAG_REF_NAME: ${{ github.ref }}
+        REPOSITORY_NAME: ${{ github.repository }}
+    - name: Upload Release Asset
+      id: upload-release-asset 
+      uses: actions/upload-release-asset@v1.0.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.get_release_info.outputs.upload_url }}
+        asset_path: ./${{ matrix.targetPlatform }}.zip
+        asset_name: ${{ steps.get_release_info.outputs.file_name }}-${{ matrix.targetPlatform }}.zip
+        asset_content_type: application/zip

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -141,7 +141,7 @@ jobs:
 
     - name: Package artifact for release
       run: |
-        zip -r ${{ matrix.targetPlatform }}.zip ./artifacts/
+        zip -r ${{ matrix.targetPlatform }}.zip ./artifacts/*
 
     - name: Get Release File Name & Upload URL
       id: get_release_info

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -141,7 +141,8 @@ jobs:
 
     - name: Package artifact for release
       run: |
-        zip -r ${{ matrix.targetPlatform }}.zip ./artifacts/*
+        zip -r ../${{ matrix.targetPlatform }}.zip .* *
+      working-directory: artifacts
 
     - name: Get Release File Name & Upload URL
       id: get_release_info

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,79 +86,79 @@ jobs:
           BRANCH: gh-pages
           FOLDER: docs/
 
- release:
-    name: Create Github Release
-    if: contains(github.ref, 'tags/v')
-    needs: [build]
-    runs-on: ubuntu-latest
-    steps:
-    - name: Create Release
-      id: create_release
-      uses: actions/create-release@v1.0.0
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ github.ref }}
-        release_name: Release ${{ github.ref }}
-        draft: false
-        prerelease: false
+  release:
+      name: Create Github Release
+      if: contains(github.ref, 'tags/v')
+      needs: [build]
+      runs-on: ubuntu-latest
+      steps:
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
 
-    - name: Output Release URL File
-      run: echo "${{ steps.create_release.outputs.upload_url }}" > release_url.txt
+      - name: Output Release URL File
+        run: echo "${{ steps.create_release.outputs.upload_url }}" > release_url.txt
 
-    - name: Save Release URL File for publish
-      uses: actions/upload-artifact@v1
-      with:
-        name: release_url
-        path: release_url.txt
+      - name: Save Release URL File for publish
+        uses: actions/upload-artifact@v1
+        with:
+          name: release_url
+          path: release_url.txt
 
-  publish:
-    if: contains(github.ref, 'tags/v')
-    needs: [build, release]
-    strategy:
-      fail-fast: false
-      matrix:
-        unityVersion:
-          - 2019.3.14f1
-        targetPlatform:
-          - StandaloneOSX
-          - StandaloneWindows
-          - StandaloneWindows64
-          - StandaloneLinux64
-          - WebGL
-    runs-on: ubuntu-latest
-    steps:
-    - name: Load Release URL File from release job
-      uses: actions/download-artifact@v1
-      with:
-        name: release_url
+    publish:
+      if: contains(github.ref, 'tags/v')
+      needs: [build, release]
+      strategy:
+        fail-fast: false
+        matrix:
+          unityVersion:
+            - 2019.3.14f1
+          targetPlatform:
+            - StandaloneOSX
+            - StandaloneWindows
+            - StandaloneWindows64
+            - StandaloneLinux64
+            - WebGL
+      runs-on: ubuntu-latest
+      steps:
+      - name: Load Release URL File from release job
+        uses: actions/download-artifact@v1
+        with:
+          name: release_url
 
-    - name: Download artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: build-${{ matrix.targetPlatform }}-${{ matrix.unityVersion }}
-        path: artifacts
+      - name: Download artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: build-${{ matrix.targetPlatform }}-${{ matrix.unityVersion }}
+          path: artifacts
 
-    - name: Package artifact for release
-      run: |
-        zip -r ${{ matrix.targetPlatform }}.zip ./artifacts/
+      - name: Package artifact for release
+        run: |
+          zip -r ${{ matrix.targetPlatform }}.zip ./artifacts/
 
-    - name: Get Release File Name & Upload URL
-      id: get_release_info
-      run: |
-        echo ::set-output name=file_name::${REPOSITORY_NAME##*/}-${TAG_REF_NAME##*/v}
-        value=`cat release_url/release_url.txt`
-        echo ::set-output name=upload_url::$value
-      env:
-        TAG_REF_NAME: ${{ github.ref }}
-        REPOSITORY_NAME: ${{ github.repository }}
-    - name: Upload Release Asset
-      id: upload-release-asset 
-      uses: actions/upload-release-asset@v1.0.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.get_release_info.outputs.upload_url }}
-        asset_path: ./${{ matrix.targetPlatform }}.zip
-        asset_name: ${{ steps.get_release_info.outputs.file_name }}-${{ matrix.targetPlatform }}.zip
-        asset_content_type: application/zip
+      - name: Get Release File Name & Upload URL
+        id: get_release_info
+        run: |
+          echo ::set-output name=file_name::${REPOSITORY_NAME##*/}-${TAG_REF_NAME##*/v}
+          value=`cat release_url/release_url.txt`
+          echo ::set-output name=upload_url::$value
+        env:
+          TAG_REF_NAME: ${{ github.ref }}
+          REPOSITORY_NAME: ${{ github.repository }}
+      - name: Upload Release Asset
+        id: upload-release-asset 
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.get_release_info.outputs.upload_url }}
+          asset_path: ./${{ matrix.targetPlatform }}.zip
+          asset_name: ${{ steps.get_release_info.outputs.file_name }}-${{ matrix.targetPlatform }}.zip
+          asset_content_type: application/zip


### PR DESCRIPTION
Create a github release and upload target platform artifacts to the release.

The release for the repository is created by the github actions job, so only the tag for the commit needs to be raised when creating a new release. The command for this is: `git tag v0.0.1 master`

