### PR TITLE
Documentation for the pipeline process

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,12 +2,12 @@
 
 ## Summary
 
-Blockycraft is a Minecraft inspired Block Engine.
+Blockycraft is a Minecraft inspired Block Engine written in Unity3D and built using GitHub Actions. The project was first developed for a University of Waterloo graphics course, and this codebase is available as [blockycraft-classic](./classic/). This version has experienced refactoring after its original submission. I decided to rewrite the project into Unity3D as I still enjoyed the concept of block engines.
 
-Blockycraft was first developed for a University of Waterloo graphics course. The [classic version](./classic/) of the project is available as `blockycraft-classic`.
+The [build pipeline](./deployment/) is done using GitHub Actions and the unity-builder actions. To avoid over-using the runners, the builds only trigger for pull requests, web deploys and releases. Using only GitHub services, it removes the need to manage deploy keys and infrastructure.
 
-## Unity Web Player
-
-You can go to the following to play on the web.
+A playable copy of the project is available at [blockycraft.jrbeverly.dev/play](https://blockycraft.jrbeverly.dev/play) or 
 
 [![Blockycraft - Unity Web Player](logo.png "Blockycraft - Unity Web Player")](play/)
+
+

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -2,4 +2,5 @@ theme: jekyll-theme-minimal
 title: Blockycraft
 description: A Minecraft inspired Block Engine.
 logo: logo.png
+logo_link_path: play/
 show_downloads: false

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,5 +1,5 @@
 theme: jekyll-theme-minimal
 title: Blockycraft
-description: Blockycraft
+description: A Minecraft inspired Block Engine.
 logo: logo.png
 show_downloads: false

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -22,9 +22,11 @@
     <div class="wrapper">
       <header>
         <h1><a href="{{ "/" | absolute_url }}">{{ site.title | default: site.github.repository_name }}</a></h1>
-        
+
         {% if site.logo %}
-          <img src="{{site.logo | relative_url}}" alt="Logo" />
+          <a href="{{ site.github.repository_url }}/{{site.logo_link_path}}">
+            <img src="{{site.logo | relative_url}}" alt="Logo" />
+          </a>
         {% endif %}
 
         <p>{{ site.description | default: site.github.project_tagline }}</p>

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -1,0 +1,29 @@
+# GitHub Actions Deployment Pipeline
+
+The Blockycraft project is built using GitHub Actions, and the compiled artifacts are deployed with GitHub Releases & GitHub Pages. The advantage to this is no external dependencies exist in the pipeline. Although external services exist that could host these artifacts (itch.io), it is far easier to deploy these artifacts using only GitHub services.
+
+The pipeline is composed of three types of runs:
+
+- Pull Request: Run the build process, exposing build artifacts for demo in changeset reviews.
+- Web Deploy: Deploy the project to GitHub Pages.
+- Release: Build project artifacts and upload to GitHub Releases.
+
+Details about these build processes are available in [.github/workflows/](.github/workflows), and documented to some degree below. A playable copy of the project is available at [blockycraft.jrbeverly.dev/play](https://blockycraft.jrbeverly.dev/play).
+
+## Continuous Integration & Web Deploy
+
+All pull requests trigger the build pipeline for the relevant target platforms. At this time, no tests are run. When running on the master branch, the process has an additional step of deploying the `WebGL` build to GitHub Pages.
+
+These builds only run on pull requests due to the required build minutes per run. By only running on pull requests, it reduce the impact of builds running for small minor changes. Ideally there would be a more efficient way to cache build artifacts to reduce this (a la hermetic builds).
+
+## Releases
+
+Releases are created when a tag is pushed for a given commit. These tags should follow semantic versioning, but there is no requirement to do so. The intent is to have a bit of flexibility when making alterations to the deployment pipeline on a development branch. From a terminal, the release process is as follows:
+
+```bash
+TAG='vMAJOR.MINOR.PATCH' # v1.2.3
+git tag $TAG master
+git push origin $TAG
+```
+
+The release pipeline is responsible for creating the GitHub Release, and only the tag needs to be created. If you wish to do so from the GitHub interface, you can create then delete a release. This will trigger a pipeline run for the newly created tag, and the release delete will prevent clashing. The release will then be "re-created" with the compiled artifacts attached as zip files.


### PR DESCRIPTION
Document the build pipeline that is using GitHub services for build, package, release and deploy.

Most of the usage of github services (pages / actions / releases) have been common usages, but the process should have a source of documentation for review when working with this at a later date.

Additional alterations have been made to the main README to simplify the extra language. Screenshots will likely be a better space filling for the project README.