### PR TITLE
Alter mesh generation to exist in a multi-threaded environment

### DIFF
--- a/blockycraft/Assets/Behaviours/Chunk.cs
+++ b/blockycraft/Assets/Behaviours/Chunk.cs
@@ -4,6 +4,7 @@ public sealed class Chunk
 {
     public MeshRenderer meshRenderer;
     public MeshFilter meshFilter;
+    public Mesh Mesh { get; set; }
     public BlockChunk Blocks { get; set; }
     public Material Voxel { get; set; }
     public int X { get; set; }
@@ -19,17 +20,14 @@ public sealed class Chunk
         gameObject.transform.position = Position;
         gameObject.name = $"Chunk {X},{Z}";
 
-        var builder = new VoxelBuilder();
-        var mesh = builder.Build(Blocks, Vector3.zero);
-
         meshRenderer = gameObject.AddComponent<MeshRenderer>();
         meshRenderer.material = Voxel;
 
         meshFilter = gameObject.AddComponent<MeshFilter>();
-        meshFilter.mesh = mesh;
+        meshFilter.mesh = Mesh;
     }
 
-    public static Chunk Create(BlockChunk blocks, Material material, int x, int z, GameObject parent)
+    public static Chunk Create(BlockChunk blocks, Material material, int x, int z, GameObject parent, Mesh mesh)
     {
         var chunk = new Chunk
         {
@@ -37,6 +35,7 @@ public sealed class Chunk
             Voxel = material,
             X = x,
             Z = z,
+            Mesh = mesh,
             Position = x * Vector3.left * BlockChunk.SIZE + z * Vector3.forward * BlockChunk.SIZE
         };
         chunk.Initialize();

--- a/blockycraft/Assets/Scripts/Biome/WorldGenerator.cs
+++ b/blockycraft/Assets/Scripts/Biome/WorldGenerator.cs
@@ -1,8 +1,8 @@
 public sealed class WorldGenerator
 {
-    public static BlockChunk Generate(Biome biome)
+    public static BlockChunk Generate(Biome biome, int chunkX, int chunkZ)
     {
-        var chunk = new BlockChunk();
+        var chunk = new BlockChunk(chunkX, chunkZ);
         var iterator = chunk.GetIterator();
         foreach (var (x, y, z) in iterator)
         {
@@ -12,9 +12,9 @@ public sealed class WorldGenerator
         return chunk;
     }
 
-    public static BlockChunk Default(BlockType type)
+    public static BlockChunk Default(BlockType type, int chunkX, int chunkZ)
     {
-        var chunk = new BlockChunk();
+        var chunk = new BlockChunk(chunkX, chunkZ);
         var iterator = chunk.GetIterator();
         foreach (var (x, y, z) in iterator)
             chunk.Blocks[x, y, z] = type;
@@ -22,9 +22,9 @@ public sealed class WorldGenerator
         return chunk;
     }
 
-    public static BlockChunk Assorted(BlockType[] types)
+    public static BlockChunk Assorted(BlockType[] types, int chunkX, int chunkZ)
     {
-        var chunk = new BlockChunk();
+        var chunk = new BlockChunk(chunkX, chunkZ);
         var iterator = chunk.GetIterator();
         foreach (var (x, y, z) in iterator)
         {

--- a/blockycraft/Assets/Scripts/Geometry/BlockChunk.cs
+++ b/blockycraft/Assets/Scripts/Geometry/BlockChunk.cs
@@ -5,10 +5,46 @@
     public int Length => Blocks.GetLength(1);
     public int Depth => Blocks.GetLength(2);
     public BlockType[,,] Blocks { get; }
+    public int X { get; set; }
+    public int Z { get; set; }
 
-    public BlockChunk()
+    public BlockChunk(int x, int z)
     {
         Blocks = new BlockType[SIZE, SIZE, SIZE];
+        X = x;
+        Z = z;
+    }
+
+    public static (int x, int y, int z) GetDirection(int x, int y, int z, BlockFace face)
+    {
+        switch (face)
+        {
+            case BlockFace.Back: return (x - 1, y, z);
+            case BlockFace.Front: return (x + 1, y, z);
+            case BlockFace.Left: return (x, y, z + 1);
+            case BlockFace.Right: return (x, y, z - 1);
+            case BlockFace.Top: return (x, y + 1, z);
+            case BlockFace.Bottom: return (x, y - 1, z);
+            default: return (x, y, z);
+        }
+    }
+
+    public bool WithinBounds(int x, int y, int z)
+    {
+        return x < 0 || x >= Blocks.GetLength(0) ||
+                   y < 0 || y >= Blocks.GetLength(1) ||
+                   z < 0 || z >= Blocks.GetLength(2);
+    }
+
+    public BlockType GetNeighbour(int x, int y, int z, BlockFace face)
+    {
+        if (!WithinBounds(x, y, z))
+        {
+            throw new System.IndexOutOfRangeException();
+        }
+
+        var (nx, ny, nz) = GetDirection(x, y, z, face);
+        return Blocks[nx, ny, nz];
     }
 
     public Iterator3D GetIterator()

--- a/blockycraft/Assets/Scripts/Geometry/ChunkFactory.cs
+++ b/blockycraft/Assets/Scripts/Geometry/ChunkFactory.cs
@@ -1,0 +1,139 @@
+﻿using System.Threading.Tasks;
+using UnityEngine;
+
+namespace Assets.Scripts.Geometry
+{
+    public static class ChunkFactory
+    {
+        public static readonly int GridSize = 8;
+        public static float GridUVFactor { get { return 1f / (float)GridSize; } }
+
+        public static Task<ChunkFab> Build(BlockChunk chunk)
+        {
+            return Task.Run(() => CreateFromBlocks(chunk));
+        }
+
+        public static bool IsObscured(BlockType[,,] blocks, int x, int y, int z)
+        {
+            if (x < 0 || x >= blocks.GetLength(0) ||
+                y < 0 || y >= blocks.GetLength(1) ||
+                z < 0 || z >= blocks.GetLength(2))
+            {
+                return false;
+            }
+
+            return blocks[x, y, z] != null;
+        }
+
+        public static int ComputeVisibleFaces(BlockChunk blocks)
+        {
+            var visible = 0;
+            var iterator = blocks.GetIterator();
+            var directions = System.Enum.GetValues(typeof(BlockFace));
+            foreach (var (x, y, z) in iterator)
+            {
+                var type = blocks.Blocks[x, y, z];
+                foreach (int face in directions)
+                {
+                    var (nx, ny, nz) = BlockChunk.GetDirection(x, y, z, (BlockFace)face);
+                    if (!IsObscured(blocks.Blocks, nx, ny, nz))
+                    {
+                        visible++;
+                    }
+                }
+            }
+            return visible;
+        }
+
+        private static ChunkFab CreateFromBlocks(BlockChunk blocks)
+        {
+            var faces = ComputeVisibleFaces(blocks);
+            var meshFab = new ChunkFab(blocks, faces);
+            int vertexIndex = 0;
+            var blockSize = 1.0f;
+            var directions = System.Enum.GetValues(typeof(BlockFace));
+
+            var iterator = blocks.GetIterator();
+            foreach (var (x, y, z) in iterator)
+            {
+                var type = blocks.Blocks[x, y, z];
+
+                var offset = (x * Vector3.right * blockSize) + (z * Vector3.forward * blockSize) + (y * Vector3.up * blockSize);
+                foreach (int face in directions)
+                {
+                    var (nx, ny, nz) = BlockChunk.GetDirection(x, y, z, (BlockFace)face);
+                    if (IsObscured(blocks.Blocks, nx, ny, nz))
+                    {
+                        continue;
+                    }
+
+                    for (int vert = 0; vert < Voxel.VerticesInFace; vert++)
+                    {
+                        meshFab.PushVertex(offset + Voxel.Vertices[Voxel.Tris[face, vert]]);
+                    }                       
+
+                    var uv = Voxel.UV(type, face, GridSize, GridUVFactor);
+                    meshFab.PushUV(uv);
+                    meshFab.PushUV(new Vector2(uv.x, uv.y + GridUVFactor));
+                    meshFab.PushUV(new Vector2(uv.x + GridUVFactor, uv.y));
+                    meshFab.PushUV(new Vector2(uv.x + GridUVFactor, uv.y + GridUVFactor));
+
+                    for (int idx = 0; idx < Voxel.Triangles.Length; idx++)
+                        meshFab.PushTriangle(vertexIndex + Voxel.Triangles[idx]);
+
+                    vertexIndex += Voxel.VerticesInFace;
+                }
+            }
+
+            return meshFab;
+        }
+    }
+
+    public sealed class ChunkFab
+    {
+        public BlockChunk Blocks { get; private set; }
+        public Vector3[] Verticies { get; private set; }
+        public int[] Triangles { get; private set; }
+        public Vector2[] UVs { get; private set; }
+        private int idxVertex, idxUV, idxTriangles;
+
+        public ChunkFab(BlockChunk blocks, int faces) {
+            Verticies = new Vector3[Voxel.VerticesInFace * faces];
+            UVs = new Vector2[Voxel.VerticesInFace * faces];
+            Triangles = new int[Voxel.Triangles.Length * faces];
+            idxVertex = idxUV = idxTriangles = 0;
+            Blocks = blocks;
+        }
+
+        public void PushUV(Vector2 uv)
+        {
+            UVs[idxUV] = uv;
+            idxUV++;
+        }
+
+        public void PushVertex(Vector3 vertex)
+        {
+            Verticies[idxVertex] = vertex;
+            idxVertex++;
+        }
+
+        public void PushTriangle(int triangle)
+        {
+            Triangles[idxTriangles] = triangle;
+            idxTriangles++;
+        }
+
+        public Mesh ToMesh()
+        {
+            var mesh = new Mesh
+            {
+                vertices = Verticies,
+                triangles = Triangles,
+                uv = UVs,
+            };
+
+            mesh.RecalculateNormals();
+            return mesh;
+        }
+    }
+}

--- a/blockycraft/Assets/Scripts/Geometry/ChunkFactory.cs.meta
+++ b/blockycraft/Assets/Scripts/Geometry/ChunkFactory.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2b91ceb956709114490cb5571712134d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/blockycraft/Assets/Scripts/Geometry/Voxel.cs
+++ b/blockycraft/Assets/Scripts/Geometry/Voxel.cs
@@ -30,4 +30,16 @@ public static class Voxel
         {4, 7, 0, 3},
         {1, 2, 5, 6}
     };
+
+    public static Vector2 UV(BlockType block, int face, int sizeOfGrid, float uvFactor)
+    {
+        var textureID = (int)BlockType.GetTextureID(block, face);
+        float y = textureID / sizeOfGrid;
+        float x = textureID - (y * sizeOfGrid);
+        return new Vector2(
+            x * uvFactor,
+            1f - (y + 1) * uvFactor
+        );
+    }
+
 }


### PR DESCRIPTION
Alter the chunk mesh generation to exist in a threaded environment.

The change is not an ideal solution, but makes the necessary changes to support building meshes in a thread-agnostic way. The `Mesh` class requires running on the main thread, so this abstracts out the primitives to exist in a threaded environment.

Additionally the `ChunkFab` has switched from a List model, to a constant array model.

This is not intended to be the final model, but I wanted to shift away from the restrictions of the single threaded model.