### PR TITLE
Disable the TPL approach due to complications with WebGL

### DIFF
--- a/blockycraft/Assets/Behaviours/World.cs
+++ b/blockycraft/Assets/Behaviours/World.cs
@@ -1,9 +1,7 @@
 ﻿using UnityEngine;
 using System;
-using System.Linq;
 using System.Collections.Generic;
 using Assets.Scripts.Geometry;
-using System.Threading.Tasks;
 
 public sealed class World : MonoBehaviour
 {
@@ -11,22 +9,6 @@ public sealed class World : MonoBehaviour
     private Dictionary<string, Chunk> chunks;
     public Material material;
     private Biome biome;
-
-    static BlockType[] ReadBlockTypes()
-    {
-        BlockType[] result;
-        try
-        {
-            result = Resources.LoadAll("BlockTypes/", typeof(BlockType)).Cast<BlockType>().ToArray();
-        }
-        catch (Exception e)
-        {
-            Debug.Log("Proper Method failed with the following exception: ");
-            Debug.Log(e);
-            throw e;
-        }
-        return result;
-    }
 
     static Biome ReadFlatBiome()
     {
@@ -46,7 +28,7 @@ public sealed class World : MonoBehaviour
 
     public void AddChunks(int centerX, int centerZ)
     {
-        var tasks = new List<Task<ChunkFab>>();
+        var tasks = new List<ChunkFab>();
         for (var i = -DRAW_DISTANCE; i <= DRAW_DISTANCE; i++)
         {
             for (var j = -DRAW_DISTANCE; j <= DRAW_DISTANCE; j++)
@@ -62,18 +44,15 @@ public sealed class World : MonoBehaviour
                 
 
                 var blocks = WorldGenerator.Generate(biome, x, z);
-                tasks.Add(ChunkFactory.Build(blocks));
+                tasks.Add(ChunkFactory.CreateFromBlocks(blocks));
             }
         }
 
 
         if (tasks.Count == 0) { return; }
-        // Ideally no.
-        Task.WaitAll(tasks.ToArray());
-
-        foreach(var task in tasks)
+        
+        foreach(var chunkFab in tasks)
         {
-            var chunkFab = task.Result;
             var key = $"{chunkFab.Blocks.X}:{chunkFab.Blocks.Z}";
             chunks[key] = Chunk.Create(chunkFab.Blocks, material, chunkFab.Blocks.X, chunkFab.Blocks.Z, gameObject, chunkFab.ToMesh());
         }

--- a/blockycraft/Assets/Scripts/Geometry/ChunkFactory.cs
+++ b/blockycraft/Assets/Scripts/Geometry/ChunkFactory.cs
@@ -1,5 +1,4 @@
-﻿using System.Threading.Tasks;
-using UnityEngine;
+﻿using UnityEngine;
 
 namespace Assets.Scripts.Geometry
 {
@@ -7,11 +6,6 @@ namespace Assets.Scripts.Geometry
     {
         public static readonly int GridSize = 8;
         public static float GridUVFactor { get { return 1f / (float)GridSize; } }
-
-        public static Task<ChunkFab> Build(BlockChunk chunk)
-        {
-            return Task.Run(() => CreateFromBlocks(chunk));
-        }
 
         public static bool IsObscured(BlockType[,,] blocks, int x, int y, int z)
         {
@@ -45,7 +39,7 @@ namespace Assets.Scripts.Geometry
             return visible;
         }
 
-        private static ChunkFab CreateFromBlocks(BlockChunk blocks)
+        public static ChunkFab CreateFromBlocks(BlockChunk blocks)
         {
             var faces = ComputeVisibleFaces(blocks);
             var meshFab = new ChunkFab(blocks, faces);


### PR DESCRIPTION
Disable the use of TPL (Task Parallel Library) due to complications with the WebGL artifact.

As WebGL is the primary entrypoint for the project, it doesn't make sense to introduced TPL if it negatively impacts the WebGL experience (or cannot be effectively leveraged).

Splitting the work up into smaller works than can be addressed in a unit of work manner should enable a smoother experience.