### PR TITLE
Fix the texture GUID for the voxel material

### DIFF
--- a/blockycraft/Assets/Materials/Voxel.mat
+++ b/blockycraft/Assets/Materials/Voxel.mat
@@ -40,7 +40,7 @@ Material:
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _MainTex:
-        m_Texture: {fileID: 2800000, guid: 3ac23b21cbfd6fb4b94dbd3902b4b1d4, type: 3}
+        m_Texture: {fileID: 2800000, guid: cb8c4e7b5eec8b042908e3201bce2e85, type: 3}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _MetallicGlossMap:


### PR DESCRIPTION
When the Blocksheet GUID was changed, the reference in `material:Voxel` was not updated.

This has the impact of altering all the scene textures to being a 'tannish' color, and no textures being shown. Fixing the GUID resolves this.