### PR TITLE
Switch to versioned secrets for Unity license

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ on:
       - "*"
 
 env:
-  UNITY_LICENSE: ${{ secrets.UNITY_LICENSE_2019_4_3F1 }}
+  UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
 
 jobs:
   build:


### PR DESCRIPTION
Convert the unity license usage to be versioned to support uninterrupted upgrades.

The unity license is stored in an environment variable named UNITY_LICENSE_{VERSION}, where {VERSION} refers to the Unity version of the project. For the version 2019.4.3f1, the secret should follow the naming convention of 2019_4_3f1.