### PR TITLE
Introduce the air block type, defining the idea of empty space

### DIFF
--- a/blockycraft/Assets/Resources/Biomes/Flat.asset
+++ b/blockycraft/Assets/Resources/Biomes/Flat.asset
@@ -17,3 +17,4 @@ MonoBehaviour:
   Blocks:
   - Type: {fileID: 11400000, guid: a8f914cd637083345854577f4a7cfd3c, type: 2}
   - Type: {fileID: 11400000, guid: 28e59d219862508419a9db71331f0f31, type: 2}
+  - Type: {fileID: 11400000, guid: 0cd8cdf8eb2ebd5458a0b45e89c61fe2, type: 2}

--- a/blockycraft/Assets/Resources/Biomes/Sand.asset
+++ b/blockycraft/Assets/Resources/Biomes/Sand.asset
@@ -16,3 +16,4 @@ MonoBehaviour:
   Generator: {fileID: 11400000, guid: cff092dda5a76d7498cee85f296f50d9, type: 2}
   Blocks:
   - Type: {fileID: 11400000, guid: 59cdc2dd76bc8de43996ac0361c1ea7d, type: 2}
+  - Type: {fileID: 11400000, guid: 0cd8cdf8eb2ebd5458a0b45e89c61fe2, type: 2}

--- a/blockycraft/Assets/Resources/BlockTypes/Air.asset
+++ b/blockycraft/Assets/Resources/BlockTypes/Air.asset
@@ -1,0 +1,24 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4b3dcbb8f276bf4d8e1be3862f9ba27, type: 3}
+  m_Name: Air
+  m_EditorClassIdentifier: 
+  blockName: Air
+  material: {fileID: 2100000, guid: 7b1043f1574203e419d8073f6a72ed8e, type: 2}
+  textures: {fileID: 11400000, guid: 0e310aebe477bee4eba6ddcebc07f5f0, type: 2}
+  isVisible: 0
+  left: dirt
+  right: dirt
+  top: dirt
+  bottom: dirt
+  front: dirt
+  back: dirt

--- a/blockycraft/Assets/Resources/BlockTypes/Air.asset.meta
+++ b/blockycraft/Assets/Resources/BlockTypes/Air.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0cd8cdf8eb2ebd5458a0b45e89c61fe2
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/blockycraft/Assets/Scripts/Biomes/FlatWorldGenerator.cs
+++ b/blockycraft/Assets/Scripts/Biomes/FlatWorldGenerator.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using System.Linq;
+using UnityEngine;
 
 namespace Assets.Scripts.Biomes
 {
@@ -7,12 +8,17 @@ namespace Assets.Scripts.Biomes
     {
         public override BlockChunk Generate(Biome biome, int chunkX, int chunkZ)
         {
+            var air = biome.Blocks.FirstOrDefault(p => !p.Type.isVisible);
             var chunk = new BlockChunk(chunkX, chunkZ);
             var iterator = chunk.GetIterator();
             foreach (var (x, y, z) in iterator)
             {
-                var idx = (x + y + z) % biome.Blocks.Length;
-                chunk.Blocks[x, y, z] = biome.Blocks[idx].Type;
+                if (air != null && y >= iterator.Height - 1 && Random.value < 0.15f) {
+                    chunk.Blocks[x, y, z] = air.Type;
+                } else {
+                    var idx = y % biome.Blocks.Length;
+                    chunk.Blocks[x, y, z] = biome.Blocks[idx].Type;
+                }
             }
             return chunk;
         }

--- a/blockycraft/Assets/Scripts/Biomes/FlatWorldGenerator.cs
+++ b/blockycraft/Assets/Scripts/Biomes/FlatWorldGenerator.cs
@@ -11,7 +11,7 @@ namespace Assets.Scripts.Biomes
             var iterator = chunk.GetIterator();
             foreach (var (x, y, z) in iterator)
             {
-                var idx = y % biome.Blocks.Length;
+                var idx = (x + y + z) % biome.Blocks.Length;
                 chunk.Blocks[x, y, z] = biome.Blocks[idx].Type;
             }
             return chunk;

--- a/blockycraft/Assets/Scripts/Geometry/BlockChunk.cs
+++ b/blockycraft/Assets/Scripts/Geometry/BlockChunk.cs
@@ -19,10 +19,10 @@
     {
         switch (face)
         {
-            case BlockFace.Back: return (x - 1, y, z);
-            case BlockFace.Front: return (x + 1, y, z);
-            case BlockFace.Left: return (x, y, z + 1);
-            case BlockFace.Right: return (x, y, z - 1);
+            case BlockFace.Left: return (x - 1, y, z);
+            case BlockFace.Right: return (x + 1, y, z);
+            case BlockFace.Back: return (x, y, z + 1);
+            case BlockFace.Front: return (x, y, z - 1);
             case BlockFace.Top: return (x, y + 1, z);
             case BlockFace.Bottom: return (x, y - 1, z);
             default: return (x, y, z);

--- a/blockycraft/Assets/Scripts/Geometry/BlockChunk.cs
+++ b/blockycraft/Assets/Scripts/Geometry/BlockChunk.cs
@@ -19,10 +19,10 @@
     {
         switch (face)
         {
-            case BlockFace.Back: return (x + 1, y, z);
-            case BlockFace.Front: return (x - 1, y, z);
-            case BlockFace.Left: return (x, y, z + 1);
-            case BlockFace.Right: return (x, y, z - 1);
+            case BlockFace.Back: return (x - 1, y, z);
+            case BlockFace.Front: return (x + 1, y, z);
+            case BlockFace.Left: return (x, y, z - 1);
+            case BlockFace.Right: return (x, y, z + 1);
             case BlockFace.Top: return (x, y + 1, z);
             case BlockFace.Bottom: return (x, y - 1, z);
             default: return (x, y, z);

--- a/blockycraft/Assets/Scripts/Geometry/BlockChunk.cs
+++ b/blockycraft/Assets/Scripts/Geometry/BlockChunk.cs
@@ -19,10 +19,10 @@
     {
         switch (face)
         {
-            case BlockFace.Left: return (x - 1, y, z);
-            case BlockFace.Right: return (x + 1, y, z);
-            case BlockFace.Back: return (x, y, z + 1);
-            case BlockFace.Front: return (x, y, z - 1);
+            case BlockFace.Back: return (x + 1, y, z);
+            case BlockFace.Front: return (x - 1, y, z);
+            case BlockFace.Left: return (x, y, z + 1);
+            case BlockFace.Right: return (x, y, z - 1);
             case BlockFace.Top: return (x, y + 1, z);
             case BlockFace.Bottom: return (x, y - 1, z);
             default: return (x, y, z);

--- a/blockycraft/Assets/Scripts/Geometry/BlockType.cs
+++ b/blockycraft/Assets/Scripts/Geometry/BlockType.cs
@@ -12,6 +12,9 @@ public sealed class BlockType : ScriptableObject
     public Material material;
     public TexturePack textures;
 
+    [Header("Properties")]
+    public bool isVisible;
+
     [Header("Texture Faces")]
     public string left;
     public string right;
@@ -19,6 +22,10 @@ public sealed class BlockType : ScriptableObject
     public string bottom;
     public string front;
     public string back;
+
+    public BlockType() {
+        isVisible = true;
+    }
 
     public static TexturePack.Element GetTextureID(BlockType block, int index)
     {

--- a/blockycraft/Assets/Scripts/Geometry/ChunkFactory.cs
+++ b/blockycraft/Assets/Scripts/Geometry/ChunkFactory.cs
@@ -7,7 +7,7 @@ namespace Assets.Scripts.Geometry
         public static readonly int GridSize = 8;
         public static float GridUVFactor { get { return 1f / (float)GridSize; } }
 
-        public static bool IsObscured(BlockType[,,] blocks, int x, int y, int z)
+        public static bool IsVisible(BlockType[,,] blocks, int x, int y, int z)
         {
             if (x < 0 || x >= blocks.GetLength(0) ||
                 y < 0 || y >= blocks.GetLength(1) ||
@@ -16,7 +16,7 @@ namespace Assets.Scripts.Geometry
                 return false;
             }
 
-            return blocks[x, y, z] != null;
+            return blocks[x, y, z].isVisible;
         }
 
         public static int ComputeVisibleFaces(BlockChunk blocks)
@@ -27,10 +27,12 @@ namespace Assets.Scripts.Geometry
             foreach (var (x, y, z) in iterator)
             {
                 var type = blocks.Blocks[x, y, z];
+                if (!type.isVisible) continue;
+
                 foreach (int face in directions)
                 {
                     var (nx, ny, nz) = BlockChunk.GetDirection(x, y, z, (BlockFace)face);
-                    if (!IsObscured(blocks.Blocks, nx, ny, nz))
+                    if (!IsVisible(blocks.Blocks, nx, ny, nz))
                     {
                         visible++;
                     }
@@ -51,12 +53,13 @@ namespace Assets.Scripts.Geometry
             foreach (var (x, y, z) in iterator)
             {
                 var type = blocks.Blocks[x, y, z];
+                if (!type.isVisible) continue;
 
                 var offset = (x * Vector3.right * blockSize) + (z * Vector3.forward * blockSize) + (y * Vector3.up * blockSize);
                 foreach (int face in directions)
                 {
                     var (nx, ny, nz) = BlockChunk.GetDirection(x, y, z, (BlockFace)face);
-                    if (IsObscured(blocks.Blocks, nx, ny, nz))
+                    if (IsVisible(blocks.Blocks, nx, ny, nz))
                     {
                         continue;
                     }

--- a/blockycraft/Assets/Scripts/Geometry/ChunkFactory.cs
+++ b/blockycraft/Assets/Scripts/Geometry/ChunkFactory.cs
@@ -32,10 +32,12 @@ namespace Assets.Scripts.Geometry
                 foreach (int face in directions)
                 {
                     var (nx, ny, nz) = BlockChunk.GetDirection(x, y, z, (BlockFace)face);
-                    if (!IsVisible(blocks.Blocks, nx, ny, nz))
+                    if (IsVisible(blocks.Blocks, nx, ny, nz))
                     {
-                        visible++;
+                        continue;
                     }
+
+                    visible++;
                 }
             }
             return visible;
@@ -55,7 +57,7 @@ namespace Assets.Scripts.Geometry
                 var type = blocks.Blocks[x, y, z];
                 if (!type.isVisible) continue;
 
-                var offset = (x * Vector3.right * blockSize) + (z * Vector3.forward * blockSize) + (y * Vector3.up * blockSize);
+                var offset = (x * Vector3.left * blockSize) + (z * Vector3.forward * blockSize) + (y * Vector3.up * blockSize);
                 foreach (int face in directions)
                 {
                     var (nx, ny, nz) = BlockChunk.GetDirection(x, y, z, (BlockFace)face);

--- a/blockycraft/Assets/Scripts/Iterator3D.cs
+++ b/blockycraft/Assets/Scripts/Iterator3D.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 public sealed class Iterator3D : IEnumerable<(int x, int y, int z)>
 {
     public int Width { get; }
-    public int Length { get; }
+    public int Height { get; }
     public int Depth { get; }
 
     public Iterator3D(int size) : this(size, size, size) { }
@@ -12,14 +12,14 @@ public sealed class Iterator3D : IEnumerable<(int x, int y, int z)>
     public Iterator3D(int width, int length, int depth)
     {
         Width = width;
-        Length = length;
+        Height = length;
         Depth = depth;
     }
 
     public IEnumerator<(int x, int y, int z)> GetEnumerator()
     {
         for (int x = 0; x < Width; x++)
-            for (int y = 0; y < Length; y++)
+            for (int y = 0; y < Height; y++)
                 for (int z = 0; z < Depth; z++)
                     yield return (x, y, z);
     }


### PR DESCRIPTION
Introduce an 'Air' block type, and add this type to the sand and flat biomes for reference.

Resolve a discrepancy with how the system checked for neighbours, and how the chunk factory positioned those people. The fix ensures that the concept of a `Neighbour` maps correctly to the visual neighbour location.

Although having `null` represent 'Air' does offer advantages, those don't really match that well when invisible blocks exist. A barrier block is a good example. This is a block that has no visible properties, but still has a bounding box. 