### PR TITLE
Support 3D chunk generation in the world

### DIFF
--- a/blockycraft/Assets/Behaviours/Chunk.cs
+++ b/blockycraft/Assets/Behaviours/Chunk.cs
@@ -8,6 +8,7 @@ public sealed class Chunk
     public BlockChunk Blocks { get; set; }
     public Material Voxel { get; set; }
     public int X { get; set; }
+    public int Y { get; set; }
     public int Z { get; set; }
     public GameObject gameObject { get; set; }
     public Vector3 Position { get; set; }
@@ -18,7 +19,7 @@ public sealed class Chunk
     {
         gameObject = new GameObject();
         gameObject.transform.position = Position;
-        gameObject.name = $"Chunk {X},{Z}";
+        gameObject.name = $"Chunk {X},{Y},{Z}";
 
         meshRenderer = gameObject.AddComponent<MeshRenderer>();
         meshRenderer.material = Voxel;
@@ -27,18 +28,20 @@ public sealed class Chunk
         meshFilter.mesh = Mesh;
     }
 
-    public static Chunk Create(BlockChunk blocks, Material material, int x, int z, GameObject parent, Mesh mesh)
+    public static Chunk Create(BlockChunk blocks, Material material, int x, int y, int z, GameObject parent, Mesh mesh)
     {
         var chunk = new Chunk
         {
             Blocks = blocks,
             Voxel = material,
             X = x,
+            Y = y,
             Z = z,
             Mesh = mesh,
-            Position = x * Vector3.left * BlockChunk.SIZE + z * Vector3.forward * BlockChunk.SIZE
+            Position = x * Vector3.left * BlockChunk.SIZE + z * Vector3.forward * BlockChunk.SIZE + y * Vector3.up * BlockChunk.SIZE
         };
         chunk.Initialize();
+
         chunk.gameObject.transform.SetParent(parent.transform);
         return chunk;
     }

--- a/blockycraft/Assets/Behaviours/Player.cs
+++ b/blockycraft/Assets/Behaviours/Player.cs
@@ -20,15 +20,16 @@ public sealed class Player : MonoBehaviour
         transform.Translate(GetMovementDirection() * Speed * Time.deltaTime);
         lastMouse = Input.mousePosition;
 
-        var (x, z) = GetChunkCoordFromPosition(transform.position);
-        world.AddChunks(-x, z);
+        var (x, y, z) = GetChunkCoordFromPosition(transform.position);
+        world.AddChunks(-x, y, z);
     }
 
-    (int x, int z) GetChunkCoordFromPosition(Vector3 position)
+    (int x, int y, int z) GetChunkCoordFromPosition(Vector3 position)
     {
         // Rough estimation of which chunk the player is currently over.
         return (
             (int)(position.x / BlockChunk.SIZE),
+            (int)(position.y / BlockChunk.SIZE),
             (int)(position.z / BlockChunk.SIZE)
         );
     }

--- a/blockycraft/Assets/Behaviours/World.cs
+++ b/blockycraft/Assets/Behaviours/World.cs
@@ -4,41 +4,32 @@ using Assets.Scripts.Geometry;
 
 public sealed class World : MonoBehaviour
 {
-    public const int DRAW_DISTANCE = 4;
+    public const int DRAW_HEIGHT = 4;
+    public const int DRAW_DISTANCE = DRAW_HEIGHT * 2;
     private Dictionary<string, Chunk> chunks;
     public Material material;
     public Biome[] biomes;
 
-    public void AddChunks(int centerX, int centerZ)
+    public void AddChunks(int centerX, int centerY, int centerZ)
     {
-        var tasks = new List<ChunkFab>();
-        for (var i = -DRAW_DISTANCE; i <= DRAW_DISTANCE; i++)
-        {
-            for (var j = -DRAW_DISTANCE; j <= DRAW_DISTANCE; j++)
+        var iterator = new Iterator3D(DRAW_DISTANCE, DRAW_HEIGHT, DRAW_DISTANCE);
+        foreach(var (ix, iy, iz) in iterator) {
+            var x = centerX + (ix - DRAW_HEIGHT);
+            var y = centerY + (iy - DRAW_HEIGHT);
+            var z = centerZ + (iz - DRAW_HEIGHT);
+
+            var key = $"{x}:{y}:{z}";
+            if (chunks.ContainsKey(key))
             {
-                var x = centerX + i;
-                var z = centerZ + j;
-
-                var key = $"{x}:{z}";
-                if (chunks.ContainsKey(key))
-                {
-                    continue;
-                }
-
-                var biome = biomes[(int)(Random.value * (biomes.Length))];
-                var generator = biome.Generator;
-                var blocks = generator.Generate(biome, x, z);
-                tasks.Add(ChunkFactory.CreateFromBlocks(blocks));
+                Debug.Log(key);
+                continue;
             }
-        }
 
-
-        if (tasks.Count == 0) { return; }
-        
-        foreach(var chunkFab in tasks)
-        {
-            var key = $"{chunkFab.Blocks.X}:{chunkFab.Blocks.Z}";
-            chunks[key] = Chunk.Create(chunkFab.Blocks, material, chunkFab.Blocks.X, chunkFab.Blocks.Z, gameObject, chunkFab.ToMesh());
+            var biome = biomes[(int)(Random.value * (biomes.Length))];
+            var generator = biome.Generator;
+            var blocks = generator.Generate(biome, x, y, z);
+            var chunkFab = ChunkFactory.CreateFromBlocks(blocks);
+            chunks[key] = Chunk.Create(chunkFab.Blocks, material, x, y, z, gameObject, chunkFab.ToMesh());
         }
     }
 
@@ -46,6 +37,6 @@ public sealed class World : MonoBehaviour
     {
         chunks = new Dictionary<string, Chunk>();
 
-        AddChunks(0, 0);
+        AddChunks(0, 0, 0);
     }
 }

--- a/blockycraft/Assets/Behaviours/World.cs
+++ b/blockycraft/Assets/Behaviours/World.cs
@@ -21,7 +21,6 @@ public sealed class World : MonoBehaviour
             var key = $"{x}:{y}:{z}";
             if (chunks.ContainsKey(key))
             {
-                Debug.Log(key);
                 continue;
             }
 

--- a/blockycraft/Assets/Scripts/Biomes/AssortedWorldGenerator.cs
+++ b/blockycraft/Assets/Scripts/Biomes/AssortedWorldGenerator.cs
@@ -6,9 +6,9 @@ namespace Assets.Scripts.Biomes
     [CreateAssetMenu(fileName = "Generator", menuName = "Blockycraft/Generators/Assorted")]
     public sealed class AssortedWorldGenerator : WorldGenerator
     {
-        public override BlockChunk Generate(Biome biome, int chunkX, int chunkZ)
+        public override BlockChunk Generate(Biome biome, int chunkX, int chunkY, int chunkZ)
         {
-            var chunk = new BlockChunk(chunkX, chunkZ);
+            var chunk = new BlockChunk(chunkX, chunkY, chunkZ);
             var iterator = chunk.GetIterator();
             foreach (var (x, y, z) in iterator)
             {

--- a/blockycraft/Assets/Scripts/Biomes/DefaultWorldGenerator.cs
+++ b/blockycraft/Assets/Scripts/Biomes/DefaultWorldGenerator.cs
@@ -8,9 +8,9 @@ namespace Assets.Scripts.Biomes
     {
         public int Index;
 
-        public override BlockChunk Generate(Biome biome, int chunkX, int chunkZ)
+        public override BlockChunk Generate(Biome biome, int chunkX, int chunkY, int chunkZ)
         {
-            var chunk = new BlockChunk(chunkX, chunkZ);
+            var chunk = new BlockChunk(chunkX, chunkY, chunkZ);
             var iterator = chunk.GetIterator();
             foreach (var (x, y, z) in iterator)
                 chunk.Blocks[x, y, z] = biome.Blocks[Index].Type;

--- a/blockycraft/Assets/Scripts/Biomes/FlatWorldGenerator.cs
+++ b/blockycraft/Assets/Scripts/Biomes/FlatWorldGenerator.cs
@@ -6,14 +6,15 @@ namespace Assets.Scripts.Biomes
     [CreateAssetMenu(fileName = "Generator", menuName = "Blockycraft/Generators/Flat")]
     public sealed class FlatWorldGenerator : WorldGenerator
     {
-        public override BlockChunk Generate(Biome biome, int chunkX, int chunkZ)
+        public override BlockChunk Generate(Biome biome, int chunkX, int chunkY, int chunkZ)
         {
             var air = biome.Blocks.FirstOrDefault(p => !p.Type.isVisible);
-            var chunk = new BlockChunk(chunkX, chunkZ);
+            var chunk = new BlockChunk(chunkX, chunkY, chunkZ);
             var iterator = chunk.GetIterator();
             foreach (var (x, y, z) in iterator)
             {
-                if (air != null && y >= iterator.Height - 1 && Random.value < 0.15f) {
+                if ((air != null && y >= iterator.Height - 1 && Random.value < 0.15f) 
+                    || chunkY*BlockChunk.SIZE+y >= BlockChunk.SIZE) {
                     chunk.Blocks[x, y, z] = air.Type;
                 } else {
                     var idx = y % biome.Blocks.Length;

--- a/blockycraft/Assets/Scripts/Biomes/WorldGenerator.cs
+++ b/blockycraft/Assets/Scripts/Biomes/WorldGenerator.cs
@@ -4,6 +4,6 @@ namespace Assets.Scripts.Biomes
 {
     public abstract class WorldGenerator : ScriptableObject
     {
-        public abstract BlockChunk Generate(Biome biome, int chunkX, int chunkZ);
+        public abstract BlockChunk Generate(Biome biome, int chunkX, int chunkY, int chunkZ);
     }
 }

--- a/blockycraft/Assets/Scripts/Geometry/BlockChunk.cs
+++ b/blockycraft/Assets/Scripts/Geometry/BlockChunk.cs
@@ -6,9 +6,10 @@
     public int Depth => Blocks.GetLength(2);
     public BlockType[,,] Blocks { get; }
     public int X { get; set; }
+    public int Y { get; set; }
     public int Z { get; set; }
 
-    public BlockChunk(int x, int z)
+    public BlockChunk(int x, int y, int z)
     {
         Blocks = new BlockType[SIZE, SIZE, SIZE];
         X = x;


### PR DESCRIPTION
Generate chunks in the full world, rather than as a plane.

Adaptions have been made to the flat world generator to prevent all chunks being filled with blocks. This is done by the concept of a ground height defined at `BlockChunk.SIZE`. This means that chunks are being generated that contain only `blocktype:air`. Proper mechanisms will want to be in-place to prevent.

The work to enable 3D chunks has shown the fragility of the current world coordinate system, as well as how the concept of a `Chunk` is integrated into the internal API. Future work will need to be done to prune extra coordinates, and consolidate around a consistent world coordinate system (e.g. with `Point3D`).

A single struct to represent all 3 coordinates will be very helpful moving forward.