### PR TITLE
Split block generation from mesh creation

### DIFF
--- a/blockycraft/Assets/Behaviours/Player.cs
+++ b/blockycraft/Assets/Behaviours/Player.cs
@@ -23,13 +23,13 @@ public sealed class Player : MonoBehaviour
         lastMouse = Input.mousePosition;
 
         var coord = GetChunkCoordFromPosition(transform.position);
-        world.AddChunks(-coord.x, coord.y, coord.z);
+        world.Ping(coord);
     }
 
     private Vector3Int GetChunkCoordFromPosition(Vector3 position)
     {
         return new Vector3Int(
-            (int)(position.x / WorldComponent.SIZE),
+            (int)(-position.x / WorldComponent.SIZE),
             (int)(position.y / WorldComponent.SIZE),
             (int)(position.z / WorldComponent.SIZE)
         );

--- a/blockycraft/Assets/Behaviours/World.cs
+++ b/blockycraft/Assets/Behaviours/World.cs
@@ -1,4 +1,5 @@
 ﻿using Assets.Scripts.Biome;
+using Assets.Scripts.World;
 using Assets.Scripts.World.Chunk;
 using System.Collections.Generic;
 using UnityEngine;
@@ -7,28 +8,28 @@ public sealed class World : MonoBehaviour
 {
     public const int DRAW_HEIGHT = 4;
     public const int DRAW_DISTANCE = DRAW_HEIGHT * 2;
+    private WorldComponent component;
     private Dictionary<string, Chunk> chunks;
     public Material material;
     public Biome[] biomes;
-
-    public void AddChunks(int centerX, int centerY, int centerZ)
+    
+    public void Ping(Vector3Int center)
     {
+        component.Ping(center);
         var iterator = new Iterator3D(DRAW_DISTANCE, DRAW_HEIGHT, DRAW_DISTANCE);
         foreach (var coord in iterator)
         {
-            var x = centerX + (coord.x - DRAW_HEIGHT);
-            var y = centerY + (coord.y - DRAW_HEIGHT);
-            var z = centerZ + (coord.z - DRAW_HEIGHT);
+            var x = center.x + (coord.x - DRAW_HEIGHT);
+            var y = center.y + (coord.y - DRAW_HEIGHT);
+            var z = center.z + (coord.z - DRAW_HEIGHT);
 
-            var key = $"{x}:{y}:{z}";
+            var key = WorldComponent.Key(x, y, z);
             if (chunks.ContainsKey(key))
             {
                 continue;
             }
 
-            var biome = biomes[(int)(Random.value * (biomes.Length))];
-            var generator = biome.Generator;
-            var blocks = generator.Generate(biome, new Vector3Int(x, y, z));
+            var blocks = component.Get(key);
             var mesh = ChunkFactory.Build(blocks);
             chunks[key] = Chunk.Create(blocks, material, x, y, z, gameObject, mesh);
         }
@@ -36,8 +37,9 @@ public sealed class World : MonoBehaviour
 
     private void Start()
     {
+        component = new WorldComponent(DRAW_DISTANCE * 2, biomes);
         chunks = new Dictionary<string, Chunk>();
 
-        AddChunks(0, 0, 0);
+        Ping(Vector3Int.zero);
     }
 }

--- a/blockycraft/Assets/Scripts/World/WorldComponent.cs
+++ b/blockycraft/Assets/Scripts/World/WorldComponent.cs
@@ -1,7 +1,57 @@
-﻿namespace Assets.Scripts.World
+﻿using Assets.Scripts.World.Chunk;
+using System.CodeDom;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Assets.Scripts.World
 {
     public sealed class WorldComponent
     {
         public const int SIZE = 8;
+        public Biome.Biome[] biomes;
+
+        private Dictionary<string, ChunkBlocks> chunks;
+        private int circum;
+        private int radius;
+
+        public WorldComponent(int circumference, Biome.Biome[] biomes)
+        {
+            chunks = new Dictionary<string, ChunkBlocks>();
+            circum = circumference;
+            radius = circumference / 2;
+            
+            this.biomes = biomes;
+        }
+
+        public static string Key(int x, int y, int z)
+        {
+            return $"{x}:{y}:{z}";
+        }
+
+        public ChunkBlocks Get(string key)
+        {
+            return chunks[key];
+        }
+
+        public void Ping(Vector3Int position)
+        {
+            var iterator = new Iterator3D(circum, circum, circum);
+            foreach (var coord in iterator)
+            {
+                var x = position.x + (coord.x - radius);
+                var y = position.y + (coord.y - radius);
+                var z = position.z + (coord.z - radius);
+                var adjusted = new Vector3Int(x, y, z);
+
+                var key = Key(x, y, z);
+                if (chunks.ContainsKey(key))
+                {
+                    continue;
+                }
+
+                var biome = biomes[(int)(Random.value * (biomes.Length))];
+                chunks[key] = biome.Generator.Generate(biome, adjusted);
+            }
+        }
     }
 }


### PR DESCRIPTION
Split the entities responsible for generating the blocks from the mesh creation.

Start the process of breaking up chunk generation to make the process less reliance on iteration of expensive mesh generation. Instead it allows each stage of chunk generation: (allocation, assignment, pre-computation, mesh initialization) to be done in smaller batches.

When fully split up, it will enable a unit-of-work style approach to chunk generation.