### PR TITLE
Support transparent blocks in the rendering pipeline

### DIFF
--- a/blockycraft/Assets/Materials/Voxel.mat
+++ b/blockycraft/Assets/Materials/Voxel.mat
@@ -8,8 +8,8 @@ Material:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: Voxel
-  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
-  m_ShaderKeywords: 
+  m_Shader: {fileID: 10751, guid: 0000000000000000f000000000000000, type: 0}
+  m_ShaderKeywords: UNITY_UI_ALPHACLIP
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
@@ -57,7 +57,8 @@ Material:
         m_Offset: {x: 0, y: 0}
     m_Floats:
     - _BumpScale: 1
-    - _Cutoff: 0.5
+    - _ColorMask: 15
+    - _Cutoff: 0.1
     - _DetailNormalMapScale: 1
     - _DstBlend: 0
     - _GlossMapScale: 1
@@ -70,7 +71,13 @@ Material:
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1
     - _SrcBlend: 1
+    - _Stencil: 0
+    - _StencilComp: 8
+    - _StencilOp: 0
+    - _StencilReadMask: 255
+    - _StencilWriteMask: 255
     - _UVSec: 0
+    - _UseUIAlphaClip: 1
     - _ZWrite: 1
     m_Colors:
     - _Color: {r: 1, g: 1, b: 1, a: 1}

--- a/blockycraft/Assets/Resources/BlockTypes/Glass.asset
+++ b/blockycraft/Assets/Resources/BlockTypes/Glass.asset
@@ -15,6 +15,8 @@ MonoBehaviour:
   blockName: Glass
   material: {fileID: 2100000, guid: 7b1043f1574203e419d8073f6a72ed8e, type: 2}
   textures: {fileID: 11400000, guid: 0e310aebe477bee4eba6ddcebc07f5f0, type: 2}
+  isVisible: 1
+  isTransparent: 1
   left: glass
   right: glass
   top: glass

--- a/blockycraft/Assets/Resources/BlockTypes/GlassFramed.asset
+++ b/blockycraft/Assets/Resources/BlockTypes/GlassFramed.asset
@@ -15,6 +15,8 @@ MonoBehaviour:
   blockName: Glass Frame
   material: {fileID: 2100000, guid: 7b1043f1574203e419d8073f6a72ed8e, type: 2}
   textures: {fileID: 11400000, guid: 0e310aebe477bee4eba6ddcebc07f5f0, type: 2}
+  isVisible: 1
+  isTransparent: 1
   left: glass_frame
   right: glass_frame
   top: glass_frame

--- a/blockycraft/Assets/Scripts/BlockType.cs
+++ b/blockycraft/Assets/Scripts/BlockType.cs
@@ -15,6 +15,7 @@ namespace Assets.Scripts
 
         [Header("Properties")]
         public bool isVisible;
+        public bool isTransparent;
 
         [Header("Texture Faces")]
         public string left;
@@ -27,6 +28,11 @@ namespace Assets.Scripts
         public BlockType()
         {
             isVisible = true;
+            isTransparent = false;
+        }
+
+        public bool IsObscure() {
+            return isVisible && !isTransparent;
         }
 
         public static TexturePack.Element GetTextureID(BlockType block, int index)

--- a/blockycraft/Assets/Scripts/World/Chunk/ChunkFactory.cs
+++ b/blockycraft/Assets/Scripts/World/Chunk/ChunkFactory.cs
@@ -14,7 +14,7 @@ namespace Assets.Scripts.World.Chunk
                 return false;
             }
 
-            return blocks[x, y, z].isVisible;
+            return blocks[x, y, z].IsObscure();
         }
 
         public static ChunkView Visibility(ChunkBlocks blocks)


### PR DESCRIPTION
Support transparent blocks in the rendering pipeline with adjustments with visibility calculations.

Transparent blocks are not included as part of the generation process as this time, but initial tests indicate that the transparency works both in world and in the block type editor.