### PR TITLE
Place highlight and placement blocks to action blocks

### DIFF
--- a/blockycraft/Assets/Behaviours/Player.cs
+++ b/blockycraft/Assets/Behaviours/Player.cs
@@ -44,21 +44,20 @@ public sealed class Player : MonoBehaviour
 
     private void UpdateActionBlock()
     {
-        float step = 8f;
-        Vector3 pos = cam.position + (cam.forward * step);
-
-        // Simple block lookup
-        int x = Mathf.FloorToInt(pos.x);
-        int y = Mathf.FloorToInt(pos.y);
-        int z = Mathf.FloorToInt(pos.z);
-        var type = world.component.GetBlock(x, y, z);
-        if (type == null)
+        var (lastPos, pos, type) = world.Detect(cam.position, cam.forward, checkIncrement, reach);
+        if (type != null)
         {
-            Debug.Log($"Issue occurred getting block at {x}:{y}{z}");
-        }
+            highlightBlock.position = pos;
+            placeBlock.position = lastPos;
 
-        highlightBlock.position = new Vector3(x, y, z);
-        placeBlock.position = new Vector3(x, y, z);
+            highlightBlock.gameObject.SetActive(true);
+            placeBlock.gameObject.SetActive(true);
+        }
+        else
+        {
+            highlightBlock.gameObject.SetActive(false);
+            placeBlock.gameObject.SetActive(false);
+        }
     }
 
     private static Vector3 GetMovementDirection()

--- a/blockycraft/Assets/Behaviours/World.cs
+++ b/blockycraft/Assets/Behaviours/World.cs
@@ -1,4 +1,5 @@
-﻿using Assets.Scripts.Biome;
+﻿using Assets.Scripts;
+using Assets.Scripts.Biome;
 using Assets.Scripts.World;
 using Assets.Scripts.World.Chunk;
 using UnityEngine;
@@ -21,6 +22,25 @@ public sealed class World : MonoBehaviour
             var mesh = ChunkFactory.Build(blocks);
             return Chunk.Create(blocks, material, v.x, v.y, v.z, gameObject, mesh);
         });
+    }
+
+    public (Vector3 lastPos, Vector3 pos, BlockType type) Detect(Vector3 position, Vector3 forward, float increment = 0.1f, float reach = 5f)
+    {
+        float step = increment;
+        Vector3 lastPos = new Vector3();
+        while (step < reach)
+        {
+            Vector3 pos = position + (forward * step);
+            var type = component.GetBlock(Mathf.FloorToInt(pos.x), Mathf.FloorToInt(pos.y), Mathf.FloorToInt(pos.z));
+            if (type != null && type.isVisible)
+            {
+                pos = new Vector3(Mathf.FloorToInt(pos.x), Mathf.FloorToInt(pos.y), Mathf.FloorToInt(pos.z));
+                return (lastPos, pos, type);
+            }
+            lastPos = new Vector3(Mathf.FloorToInt(pos.x), Mathf.FloorToInt(pos.y), Mathf.FloorToInt(pos.z));
+            step += increment;
+        }
+        return (Vector3.zero, Vector3.zero, null);
     }
 
     private void Start()


### PR DESCRIPTION
Place the highlight and placement blocks based on the action positions.

Launch a ray into the scene to attempt to determine the next non-air (e.g. visible) block that an action can be performed on. This could be split into an 'IsDestroyable' or 'CanPlace' checks, but for now `Visible` is sufficient.