### PR TITLE
Support block destruction and placement

### DIFF
--- a/blockycraft/Assets/Behaviours/Chunk.cs
+++ b/blockycraft/Assets/Behaviours/Chunk.cs
@@ -1,4 +1,5 @@
-﻿using Assets.Scripts.World;
+﻿using Assets.Scripts;
+using Assets.Scripts.World;
 using Assets.Scripts.World.Chunk;
 using UnityEngine;
 
@@ -29,6 +30,20 @@ public sealed class Chunk
 
         meshFilter = gameObject.AddComponent<MeshFilter>();
         meshFilter.mesh = Mesh;
+    }
+
+    public void Edit(Vector3Int coord, BlockType type)
+    {
+        if (!Blocks.Contains(coord.x, coord.y, coord.z) || Blocks.Blocks[coord.x, coord.y, coord.z] == type)
+        {
+            return;
+        }
+
+        Blocks.Blocks[coord.x, coord.y, coord.z] = type;
+
+        var mesh = ChunkFactory.Build(Blocks);
+        Mesh = mesh;
+        meshFilter.mesh = mesh;
     }
 
     public static Chunk Create(ChunkBlocks blocks, Material material, int x, int y, int z, GameObject parent, Mesh mesh)

--- a/blockycraft/Assets/Behaviours/Player.cs
+++ b/blockycraft/Assets/Behaviours/Player.cs
@@ -1,4 +1,5 @@
-﻿using Assets.Scripts.World;
+﻿using Assets.Scripts;
+using Assets.Scripts.World;
 using UnityEngine;
 
 public sealed class Player : MonoBehaviour
@@ -11,6 +12,8 @@ public sealed class Player : MonoBehaviour
     public Transform cam;
     public Transform highlightBlock;
     public Transform placeBlock;
+    public BlockType air;
+    public BlockType selected;
     public float checkIncrement = 0.1f;
     public float reach = 8f;
 
@@ -31,6 +34,7 @@ public sealed class Player : MonoBehaviour
 
         // A rough action block highlight
         UpdateActionBlock();
+        ProcessActions();
     }
 
     private Vector3Int GetChunkCoordFromPosition(Vector3 position)
@@ -40,6 +44,26 @@ public sealed class Player : MonoBehaviour
             (int)(position.y / WorldComponent.SIZE),
             (int)(position.z / WorldComponent.SIZE)
         );
+    }
+
+    private void ProcessActions()
+    {
+        if (!highlightBlock.gameObject.activeSelf)
+        {
+            return;
+        }
+
+        // Destroy block.
+        if (Input.GetMouseButtonDown(0))
+        {
+            world.Set(highlightBlock.position, air);
+        }
+            
+        // Place block.
+        if (Input.GetMouseButtonDown(1))
+        {
+            world.Set(placeBlock.position, selected);
+        }
     }
 
     private void UpdateActionBlock()

--- a/blockycraft/Assets/Behaviours/World.cs
+++ b/blockycraft/Assets/Behaviours/World.cs
@@ -24,6 +24,18 @@ public sealed class World : MonoBehaviour
         });
     }
 
+    public void Set(Vector3 target, BlockType type)
+    {
+        var coord = MathHelper.Anchor(Mathf.FloorToInt(target.x), Mathf.FloorToInt(target.y), Mathf.FloorToInt(target.z), WorldComponent.SIZE);
+        var block = MathHelper.Wrap(Mathf.FloorToInt(target.x), Mathf.FloorToInt(target.y), Mathf.FloorToInt(target.z), WorldComponent.SIZE);
+        if (!chunks.TryGet(ref coord, out Chunk chunk))
+        {
+            return;
+        }
+
+        chunk.Edit(block, type);
+    }
+
     public (Vector3 lastPos, Vector3 pos, BlockType type) Detect(Vector3 position, Vector3 forward, float increment = 0.1f, float reach = 5f)
     {
         float step = increment;

--- a/blockycraft/Assets/Scenes/Blockycraft.unity
+++ b/blockycraft/Assets/Scenes/Blockycraft.unity
@@ -406,6 +406,8 @@ MonoBehaviour:
   cam: {fileID: 963194228}
   highlightBlock: {fileID: 1551536749}
   placeBlock: {fileID: 1691497281}
+  air: {fileID: 11400000, guid: 0cd8cdf8eb2ebd5458a0b45e89c61fe2, type: 2}
+  selected: {fileID: 11400000, guid: a8f914cd637083345854577f4a7cfd3c, type: 2}
   checkIncrement: 0.1
   reach: 8
 --- !u!1 &1112436239


### PR DESCRIPTION
Support block destruction and placement with a fixed type.

The block for placement is fixed as dirt, and will need a UI element for block rotations. This way we can place multiple types and blocks and have a visual indicator for this.

This requires an immediate rebuild of the chunk mesh when the state is changed. This is less than ideal, as it doesn't allow batching of alterations to a scene. The concept of a 'dirty state' fits this model a bit better, as it allows for scheduling regenerations based on the dirty state of chunks.