### PR TITLE
Resolve null-value errors with BlockType in editor

### DIFF
--- a/blockycraft/Assets/Editor/BlockTypeEditor.cs
+++ b/blockycraft/Assets/Editor/BlockTypeEditor.cs
@@ -36,7 +36,7 @@ public class BlockTypeEditor : Editor
 
         targetMeshFilter = previewRendererObject.GetComponent<MeshFilter>();
         targetMeshRenderer = previewRendererObject.GetComponent<MeshRenderer>();
-        targetMeshRenderer.transform.position = -Voxel.Center;
+        previewRendererObject.transform.position = -Voxel.Center;
     }
 
     private void InitializeLighting(PreviewRenderUtility utility)
@@ -57,6 +57,11 @@ public class BlockTypeEditor : Editor
 
     private void ReloadMesh(GameObject previewRendererObject, BlockType block)
     {
+        if (previewRendererObject == null)
+        {
+            return;
+        }
+
         var mesh = ChunkFactory.Build(block);
         previewRendererObject.GetComponent<MeshFilter>().mesh = mesh;
     }
@@ -69,7 +74,6 @@ public class BlockTypeEditor : Editor
         {
             ReloadMesh(previewRendererObject, (BlockType)target);
         }
-
         GUILayout.Label("Viewer", EditorStyles.boldLabel);
 
         EditorGUILayout.BeginHorizontal();
@@ -113,6 +117,7 @@ public class BlockTypeEditor : Editor
         if (GUILayout.Button("Reset"))
         {
             previewRendererObject.transform.rotation = Quaternion.identity;
+            previewRendererObject.transform.position = -Voxel.Center;
         }
         EditorGUILayout.EndHorizontal();
         EditorGUILayout.EndFoldoutHeaderGroup();
@@ -121,6 +126,10 @@ public class BlockTypeEditor : Editor
     public override bool HasPreviewGUI()
     {
         if (!(target is BlockType))
+            return false;
+
+        var block = (BlockType)target;
+        if (!block.IsValid())
             return false;
 
         Initialize((BlockType)target);
@@ -134,7 +143,10 @@ public class BlockTypeEditor : Editor
             return;
 
         var block = (BlockType)target;
-        targetMeshRenderer.sharedMaterial = block.material;
+        if (block.textures == null)
+            return;
+
+        targetMeshRenderer.sharedMaterial = block.textures.Material;
 
         previewRenderUtility.BeginPreview(r, background);
         previewRenderUtility.DrawMesh(targetMeshFilter.sharedMesh,

--- a/blockycraft/Assets/Scripts/BlockType.cs
+++ b/blockycraft/Assets/Scripts/BlockType.cs
@@ -9,12 +9,12 @@ namespace Assets.Scripts
     {
         [Header("Descriptors")]
         public string blockName;
-
-        public Material material;
         public TexturePack textures;
 
         [Header("Properties")]
+        [Tooltip("Determines if the block has a visibility component.")]
         public bool isVisible;
+        [Tooltip("Determines if the block can be seen through.")]
         public bool isTransparent;
 
         [Header("Texture Faces")]
@@ -31,20 +31,42 @@ namespace Assets.Scripts
             isTransparent = false;
         }
 
-        public bool IsObscure() {
+        public bool IsObscure()
+        {
             return isVisible && !isTransparent;
         }
 
-        public static TexturePack.Element GetTextureID(BlockType block, int index)
+        public bool IsValid()
         {
-            switch ((VoxelFace)index)
+            if (textures == null)
             {
-                case VoxelFace.Back: return block.textures.Find(block.back);
-                case VoxelFace.Front: return block.textures.Find(block.front);
-                case VoxelFace.Top: return block.textures.Find(block.top);
-                case VoxelFace.Bottom: return block.textures.Find(block.bottom);
-                case VoxelFace.Left: return block.textures.Find(block.left);
-                case VoxelFace.Right: return block.textures.Find(block.right);
+                return false;
+            }
+            if (
+                string.IsNullOrEmpty(back) ||
+                string.IsNullOrEmpty(front) ||
+                string.IsNullOrEmpty(top) ||
+                string.IsNullOrEmpty(bottom) ||
+                string.IsNullOrEmpty(left) ||
+                string.IsNullOrEmpty(right)
+               )
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        public static string GetTextureID(BlockType block, VoxelFace face)
+        {
+            switch (face)
+            {
+                case VoxelFace.Back: return block.back;
+                case VoxelFace.Front: return block.front;
+                case VoxelFace.Top: return block.top;
+                case VoxelFace.Bottom: return block.bottom;
+                case VoxelFace.Left: return block.left;
+                case VoxelFace.Right: return block.right;
                 default: throw new NotSupportedException();
             };
         }

--- a/blockycraft/Assets/Scripts/World/Chunk/ChunkFactory.cs
+++ b/blockycraft/Assets/Scripts/World/Chunk/ChunkFactory.cs
@@ -59,7 +59,7 @@ namespace Assets.Scripts.World.Chunk
                         meshFab.PushVertex(offset + Voxel.Vertices[Voxel.Tris[face, vert]]);
                     }
 
-                    var textureID = BlockType.GetTextureID(type, face);
+                    var textureID = BlockType.GetTextureID(type, (VoxelFace)face);
                     var texture = type.textures.Find(textureID);
                     var uv = type.textures.UV(texture);
                     var dimensions = type.textures.Dimensions(texture);

--- a/blockycraft/Assets/Scripts/World/Chunk/ChunkFactory.cs
+++ b/blockycraft/Assets/Scripts/World/Chunk/ChunkFactory.cs
@@ -59,7 +59,8 @@ namespace Assets.Scripts.World.Chunk
                         meshFab.PushVertex(offset + Voxel.Vertices[Voxel.Tris[face, vert]]);
                     }
 
-                    var texture = BlockType.GetTextureID(type, face);
+                    var textureID = BlockType.GetTextureID(type, face);
+                    var texture = type.textures.Find(textureID);
                     var uv = type.textures.UV(texture);
                     var dimensions = type.textures.Dimensions(texture);
 


### PR DESCRIPTION
Validate the state of a BlockType to avoid issues with texture resolution.

The API for texture element has been slightly adjusted to remove the reliance on resolving the texture pack element. This now just returns the TextureID based on the voxel face.

Additionally some cleanup has been performed on the BlockType to remove unused types.