### PR TITLE
Prune unused properties from BlockType assets

### DIFF
--- a/blockycraft/Assets/Resources/BlockTypes/Air.asset
+++ b/blockycraft/Assets/Resources/BlockTypes/Air.asset
@@ -13,9 +13,9 @@ MonoBehaviour:
   m_Name: Air
   m_EditorClassIdentifier: 
   blockName: Air
-  material: {fileID: 2100000, guid: 7b1043f1574203e419d8073f6a72ed8e, type: 2}
   textures: {fileID: 11400000, guid: 0e310aebe477bee4eba6ddcebc07f5f0, type: 2}
   isVisible: 0
+  isTransparent: 0
   left: dirt
   right: dirt
   top: dirt

--- a/blockycraft/Assets/Resources/BlockTypes/BrickGrey.asset
+++ b/blockycraft/Assets/Resources/BlockTypes/BrickGrey.asset
@@ -13,9 +13,9 @@ MonoBehaviour:
   m_Name: BrickGrey
   m_EditorClassIdentifier: 
   blockName: Grey Brick
-  material: {fileID: 2100000, guid: 7b1043f1574203e419d8073f6a72ed8e, type: 2}
   textures: {fileID: 11400000, guid: 0e310aebe477bee4eba6ddcebc07f5f0, type: 2}
   isVisible: 1
+  isTransparent: 0
   left: brick_grey
   right: brick_grey
   top: brick_grey

--- a/blockycraft/Assets/Resources/BlockTypes/BrickRed.asset
+++ b/blockycraft/Assets/Resources/BlockTypes/BrickRed.asset
@@ -13,8 +13,9 @@ MonoBehaviour:
   m_Name: BrickRed
   m_EditorClassIdentifier: 
   blockName: Red Brick
-  material: {fileID: 2100000, guid: 7b1043f1574203e419d8073f6a72ed8e, type: 2}
   textures: {fileID: 11400000, guid: 0e310aebe477bee4eba6ddcebc07f5f0, type: 2}
+  isVisible: 1
+  isTransparent: 0
   left: brick_red
   right: brick_red
   top: brick_red

--- a/blockycraft/Assets/Resources/BlockTypes/Cactus.asset
+++ b/blockycraft/Assets/Resources/BlockTypes/Cactus.asset
@@ -12,9 +12,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f4b3dcbb8f276bf4d8e1be3862f9ba27, type: 3}
   m_Name: Cactus
   m_EditorClassIdentifier: 
-  blockName: Dirt
-  material: {fileID: 2100000, guid: 7b1043f1574203e419d8073f6a72ed8e, type: 2}
+  blockName: Cactus
   textures: {fileID: 11400000, guid: 0e310aebe477bee4eba6ddcebc07f5f0, type: 2}
+  isVisible: 1
+  isTransparent: 0
   left: cactus_side
   right: cactus_side
   top: cactus_top

--- a/blockycraft/Assets/Resources/BlockTypes/CottonBlue.asset
+++ b/blockycraft/Assets/Resources/BlockTypes/CottonBlue.asset
@@ -13,8 +13,9 @@ MonoBehaviour:
   m_Name: CottonBlue
   m_EditorClassIdentifier: 
   blockName: Blue Cotton
-  material: {fileID: 2100000, guid: 7b1043f1574203e419d8073f6a72ed8e, type: 2}
   textures: {fileID: 11400000, guid: 0e310aebe477bee4eba6ddcebc07f5f0, type: 2}
+  isVisible: 1
+  isTransparent: 0
   left: cotton_blue
   right: cotton_blue
   top: cotton_blue

--- a/blockycraft/Assets/Resources/BlockTypes/CottonGreen.asset
+++ b/blockycraft/Assets/Resources/BlockTypes/CottonGreen.asset
@@ -12,9 +12,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f4b3dcbb8f276bf4d8e1be3862f9ba27, type: 3}
   m_Name: CottonGreen
   m_EditorClassIdentifier: 
-  blockName: Dirt
-  material: {fileID: 2100000, guid: 7b1043f1574203e419d8073f6a72ed8e, type: 2}
+  blockName: Green Cotton
   textures: {fileID: 11400000, guid: 0e310aebe477bee4eba6ddcebc07f5f0, type: 2}
+  isVisible: 1
+  isTransparent: 0
   left: cotton_green
   right: cotton_green
   top: cotton_green

--- a/blockycraft/Assets/Resources/BlockTypes/CottonRed.asset
+++ b/blockycraft/Assets/Resources/BlockTypes/CottonRed.asset
@@ -13,8 +13,9 @@ MonoBehaviour:
   m_Name: CottonRed
   m_EditorClassIdentifier: 
   blockName: Red Cotton
-  material: {fileID: 2100000, guid: 7b1043f1574203e419d8073f6a72ed8e, type: 2}
   textures: {fileID: 11400000, guid: 0e310aebe477bee4eba6ddcebc07f5f0, type: 2}
+  isVisible: 1
+  isTransparent: 0
   left: cotton_red
   right: cotton_red
   top: cotton_red

--- a/blockycraft/Assets/Resources/BlockTypes/CottonTan.asset
+++ b/blockycraft/Assets/Resources/BlockTypes/CottonTan.asset
@@ -12,9 +12,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f4b3dcbb8f276bf4d8e1be3862f9ba27, type: 3}
   m_Name: CottonTan
   m_EditorClassIdentifier: 
-  blockName: Red Cotton
-  material: {fileID: 2100000, guid: 7b1043f1574203e419d8073f6a72ed8e, type: 2}
+  blockName: Tan Cotton
   textures: {fileID: 11400000, guid: 0e310aebe477bee4eba6ddcebc07f5f0, type: 2}
+  isVisible: 1
+  isTransparent: 0
   left: cotton_tan
   right: cotton_tan
   top: cotton_tan

--- a/blockycraft/Assets/Resources/BlockTypes/Dirt.asset
+++ b/blockycraft/Assets/Resources/BlockTypes/Dirt.asset
@@ -13,8 +13,9 @@ MonoBehaviour:
   m_Name: Dirt
   m_EditorClassIdentifier: 
   blockName: Dirt
-  material: {fileID: 2100000, guid: 7b1043f1574203e419d8073f6a72ed8e, type: 2}
   textures: {fileID: 11400000, guid: 0e310aebe477bee4eba6ddcebc07f5f0, type: 2}
+  isVisible: 1
+  isTransparent: 0
   left: dirt
   right: dirt
   top: dirt

--- a/blockycraft/Assets/Resources/BlockTypes/DirtGrass.asset
+++ b/blockycraft/Assets/Resources/BlockTypes/DirtGrass.asset
@@ -12,9 +12,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f4b3dcbb8f276bf4d8e1be3862f9ba27, type: 3}
   m_Name: DirtGrass
   m_EditorClassIdentifier: 
-  blockName: Grass
-  material: {fileID: 2100000, guid: 7b1043f1574203e419d8073f6a72ed8e, type: 2}
+  blockName: Grass (Dirt)
   textures: {fileID: 11400000, guid: 0e310aebe477bee4eba6ddcebc07f5f0, type: 2}
+  isVisible: 1
+  isTransparent: 0
   left: dirt_grass
   right: dirt_grass
   top: grass_top

--- a/blockycraft/Assets/Resources/BlockTypes/DirtSand.asset
+++ b/blockycraft/Assets/Resources/BlockTypes/DirtSand.asset
@@ -12,9 +12,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f4b3dcbb8f276bf4d8e1be3862f9ba27, type: 3}
   m_Name: DirtSand
   m_EditorClassIdentifier: 
-  blockName: Dirt
-  material: {fileID: 2100000, guid: 7b1043f1574203e419d8073f6a72ed8e, type: 2}
+  blockName: Sand (Dirt)
   textures: {fileID: 11400000, guid: 0e310aebe477bee4eba6ddcebc07f5f0, type: 2}
+  isVisible: 1
+  isTransparent: 0
   left: dirt_sand
   right: dirt_sand
   top: sand

--- a/blockycraft/Assets/Resources/BlockTypes/DirtSnow.asset
+++ b/blockycraft/Assets/Resources/BlockTypes/DirtSnow.asset
@@ -12,9 +12,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f4b3dcbb8f276bf4d8e1be3862f9ba27, type: 3}
   m_Name: DirtSnow
   m_EditorClassIdentifier: 
-  blockName: Dirt
-  material: {fileID: 2100000, guid: 7b1043f1574203e419d8073f6a72ed8e, type: 2}
+  blockName: Snow (Dirt)
   textures: {fileID: 11400000, guid: 0e310aebe477bee4eba6ddcebc07f5f0, type: 2}
+  isVisible: 1
+  isTransparent: 0
   left: dirt_snow
   right: dirt_snow
   top: snow

--- a/blockycraft/Assets/Resources/BlockTypes/Glass.asset
+++ b/blockycraft/Assets/Resources/BlockTypes/Glass.asset
@@ -13,7 +13,6 @@ MonoBehaviour:
   m_Name: Glass
   m_EditorClassIdentifier: 
   blockName: Glass
-  material: {fileID: 2100000, guid: 7b1043f1574203e419d8073f6a72ed8e, type: 2}
   textures: {fileID: 11400000, guid: 0e310aebe477bee4eba6ddcebc07f5f0, type: 2}
   isVisible: 1
   isTransparent: 1

--- a/blockycraft/Assets/Resources/BlockTypes/GlassFramed.asset
+++ b/blockycraft/Assets/Resources/BlockTypes/GlassFramed.asset
@@ -13,7 +13,6 @@ MonoBehaviour:
   m_Name: GlassFramed
   m_EditorClassIdentifier: 
   blockName: Glass Frame
-  material: {fileID: 2100000, guid: 7b1043f1574203e419d8073f6a72ed8e, type: 2}
   textures: {fileID: 11400000, guid: 0e310aebe477bee4eba6ddcebc07f5f0, type: 2}
   isVisible: 1
   isTransparent: 1

--- a/blockycraft/Assets/Resources/BlockTypes/Grass.asset
+++ b/blockycraft/Assets/Resources/BlockTypes/Grass.asset
@@ -12,9 +12,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f4b3dcbb8f276bf4d8e1be3862f9ba27, type: 3}
   m_Name: Grass
   m_EditorClassIdentifier: 
-  blockName: Dirt
-  material: {fileID: 2100000, guid: 7b1043f1574203e419d8073f6a72ed8e, type: 2}
+  blockName: Grass
   textures: {fileID: 11400000, guid: 0e310aebe477bee4eba6ddcebc07f5f0, type: 2}
+  isVisible: 1
+  isTransparent: 0
   left: grass_top
   right: grass_top
   top: grass_top

--- a/blockycraft/Assets/Resources/BlockTypes/GravelDirt.asset
+++ b/blockycraft/Assets/Resources/BlockTypes/GravelDirt.asset
@@ -13,8 +13,9 @@ MonoBehaviour:
   m_Name: GravelDirt
   m_EditorClassIdentifier: 
   blockName: Dirt Gravel
-  material: {fileID: 2100000, guid: 7b1043f1574203e419d8073f6a72ed8e, type: 2}
   textures: {fileID: 11400000, guid: 0e310aebe477bee4eba6ddcebc07f5f0, type: 2}
+  isVisible: 1
+  isTransparent: 0
   left: gravel_dirt
   right: gravel_dirt
   top: gravel_dirt

--- a/blockycraft/Assets/Resources/BlockTypes/GravelStone.asset
+++ b/blockycraft/Assets/Resources/BlockTypes/GravelStone.asset
@@ -13,8 +13,9 @@ MonoBehaviour:
   m_Name: GravelStone
   m_EditorClassIdentifier: 
   blockName: Stone Gravel
-  material: {fileID: 2100000, guid: 7b1043f1574203e419d8073f6a72ed8e, type: 2}
   textures: {fileID: 11400000, guid: 0e310aebe477bee4eba6ddcebc07f5f0, type: 2}
+  isVisible: 1
+  isTransparent: 0
   left: gravel_stone
   right: gravel_stone
   top: gravel_stone

--- a/blockycraft/Assets/Resources/BlockTypes/Greysand.asset
+++ b/blockycraft/Assets/Resources/BlockTypes/Greysand.asset
@@ -13,8 +13,9 @@ MonoBehaviour:
   m_Name: Greysand
   m_EditorClassIdentifier: 
   blockName: Greysand
-  material: {fileID: 2100000, guid: 7b1043f1574203e419d8073f6a72ed8e, type: 2}
   textures: {fileID: 11400000, guid: 0e310aebe477bee4eba6ddcebc07f5f0, type: 2}
+  isVisible: 1
+  isTransparent: 0
   left: greysand
   right: greysand
   top: greysand

--- a/blockycraft/Assets/Resources/BlockTypes/Greystone.asset
+++ b/blockycraft/Assets/Resources/BlockTypes/Greystone.asset
@@ -13,8 +13,9 @@ MonoBehaviour:
   m_Name: Greystone
   m_EditorClassIdentifier: 
   blockName: Greystone
-  material: {fileID: 2100000, guid: 7b1043f1574203e419d8073f6a72ed8e, type: 2}
   textures: {fileID: 11400000, guid: 0e310aebe477bee4eba6ddcebc07f5f0, type: 2}
+  isVisible: 1
+  isTransparent: 0
   left: greystone
   right: greystone
   top: greystone

--- a/blockycraft/Assets/Resources/BlockTypes/GreystoneRuby.asset
+++ b/blockycraft/Assets/Resources/BlockTypes/GreystoneRuby.asset
@@ -13,8 +13,9 @@ MonoBehaviour:
   m_Name: GreystoneRuby
   m_EditorClassIdentifier: 
   blockName: Greystone Ruby
-  material: {fileID: 2100000, guid: 7b1043f1574203e419d8073f6a72ed8e, type: 2}
   textures: {fileID: 11400000, guid: 0e310aebe477bee4eba6ddcebc07f5f0, type: 2}
+  isVisible: 1
+  isTransparent: 0
   left: greystone_ruby
   right: greystone_ruby
   top: greystone_ruby_alt

--- a/blockycraft/Assets/Resources/BlockTypes/GreystoneSand.asset
+++ b/blockycraft/Assets/Resources/BlockTypes/GreystoneSand.asset
@@ -13,8 +13,9 @@ MonoBehaviour:
   m_Name: GreystoneSand
   m_EditorClassIdentifier: 
   blockName: Greystone Sand
-  material: {fileID: 2100000, guid: 7b1043f1574203e419d8073f6a72ed8e, type: 2}
   textures: {fileID: 11400000, guid: 0e310aebe477bee4eba6ddcebc07f5f0, type: 2}
+  isVisible: 1
+  isTransparent: 0
   left: greystone_sand
   right: greystone_sand
   top: greysand

--- a/blockycraft/Assets/Resources/BlockTypes/Ice.asset
+++ b/blockycraft/Assets/Resources/BlockTypes/Ice.asset
@@ -13,8 +13,9 @@ MonoBehaviour:
   m_Name: Ice
   m_EditorClassIdentifier: 
   blockName: Ice
-  material: {fileID: 2100000, guid: 7b1043f1574203e419d8073f6a72ed8e, type: 2}
   textures: {fileID: 11400000, guid: 0e310aebe477bee4eba6ddcebc07f5f0, type: 2}
+  isVisible: 1
+  isTransparent: 0
   left: ice
   right: ice
   top: ice

--- a/blockycraft/Assets/Resources/BlockTypes/Lava.asset
+++ b/blockycraft/Assets/Resources/BlockTypes/Lava.asset
@@ -13,8 +13,9 @@ MonoBehaviour:
   m_Name: Lava
   m_EditorClassIdentifier: 
   blockName: Lava
-  material: {fileID: 2100000, guid: 7b1043f1574203e419d8073f6a72ed8e, type: 2}
   textures: {fileID: 11400000, guid: 0e310aebe477bee4eba6ddcebc07f5f0, type: 2}
+  isVisible: 1
+  isTransparent: 0
   left: lava
   right: lava
   top: lava

--- a/blockycraft/Assets/Resources/BlockTypes/Leaves.asset
+++ b/blockycraft/Assets/Resources/BlockTypes/Leaves.asset
@@ -12,9 +12,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f4b3dcbb8f276bf4d8e1be3862f9ba27, type: 3}
   m_Name: Leaves
   m_EditorClassIdentifier: 
-  blockName: Leaves
-  material: {fileID: 2100000, guid: 7b1043f1574203e419d8073f6a72ed8e, type: 2}
+  blockName: Dense Leaves
   textures: {fileID: 11400000, guid: 0e310aebe477bee4eba6ddcebc07f5f0, type: 2}
+  isVisible: 1
+  isTransparent: 0
   left: leaves
   right: leaves
   top: leaves

--- a/blockycraft/Assets/Resources/BlockTypes/LeavesAlt.asset
+++ b/blockycraft/Assets/Resources/BlockTypes/LeavesAlt.asset
@@ -13,8 +13,9 @@ MonoBehaviour:
   m_Name: LeavesAlt
   m_EditorClassIdentifier: 
   blockName: Leaves
-  material: {fileID: 2100000, guid: 7b1043f1574203e419d8073f6a72ed8e, type: 2}
   textures: {fileID: 11400000, guid: 0e310aebe477bee4eba6ddcebc07f5f0, type: 2}
+  isVisible: 1
+  isTransparent: 0
   left: leaves_transparent
   right: leaves_transparent
   top: leaves_transparent

--- a/blockycraft/Assets/Resources/BlockTypes/LeavesOrange.asset
+++ b/blockycraft/Assets/Resources/BlockTypes/LeavesOrange.asset
@@ -12,9 +12,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f4b3dcbb8f276bf4d8e1be3862f9ba27, type: 3}
   m_Name: LeavesOrange
   m_EditorClassIdentifier: 
-  blockName: Fall Leaves
-  material: {fileID: 2100000, guid: 7b1043f1574203e419d8073f6a72ed8e, type: 2}
+  blockName: Dense Fall Leaves
   textures: {fileID: 11400000, guid: 0e310aebe477bee4eba6ddcebc07f5f0, type: 2}
+  isVisible: 1
+  isTransparent: 0
   left: leaves_orange
   right: leaves_orange
   top: leaves_orange

--- a/blockycraft/Assets/Resources/BlockTypes/LeavesOrangeAlt.asset
+++ b/blockycraft/Assets/Resources/BlockTypes/LeavesOrangeAlt.asset
@@ -13,8 +13,9 @@ MonoBehaviour:
   m_Name: LeavesOrangeAlt
   m_EditorClassIdentifier: 
   blockName: Fall Leaves
-  material: {fileID: 2100000, guid: 7b1043f1574203e419d8073f6a72ed8e, type: 2}
   textures: {fileID: 11400000, guid: 0e310aebe477bee4eba6ddcebc07f5f0, type: 2}
+  isVisible: 1
+  isTransparent: 0
   left: leaves_orange_transparent
   right: leaves_orange_transparent
   top: leaves_orange_transparent

--- a/blockycraft/Assets/Resources/BlockTypes/LogBirch.asset
+++ b/blockycraft/Assets/Resources/BlockTypes/LogBirch.asset
@@ -13,8 +13,9 @@ MonoBehaviour:
   m_Name: LogBirch
   m_EditorClassIdentifier: 
   blockName: Birch Log
-  material: {fileID: 2100000, guid: 7b1043f1574203e419d8073f6a72ed8e, type: 2}
   textures: {fileID: 11400000, guid: 0e310aebe477bee4eba6ddcebc07f5f0, type: 2}
+  isVisible: 1
+  isTransparent: 0
   left: trunk_white_side
   right: trunk_white_side
   top: trunk_white_top

--- a/blockycraft/Assets/Resources/BlockTypes/LogOak.asset
+++ b/blockycraft/Assets/Resources/BlockTypes/LogOak.asset
@@ -13,8 +13,9 @@ MonoBehaviour:
   m_Name: LogOak
   m_EditorClassIdentifier: 
   blockName: Oak Log
-  material: {fileID: 2100000, guid: 7b1043f1574203e419d8073f6a72ed8e, type: 2}
   textures: {fileID: 11400000, guid: 0e310aebe477bee4eba6ddcebc07f5f0, type: 2}
+  isVisible: 1
+  isTransparent: 0
   left: trunk_side
   right: trunk_side
   top: trunk_top

--- a/blockycraft/Assets/Resources/BlockTypes/OreBrownIron.asset
+++ b/blockycraft/Assets/Resources/BlockTypes/OreBrownIron.asset
@@ -13,8 +13,9 @@ MonoBehaviour:
   m_Name: OreBrownIron
   m_EditorClassIdentifier: 
   blockName: Brown Iron Ore
-  material: {fileID: 2100000, guid: 7b1043f1574203e419d8073f6a72ed8e, type: 2}
   textures: {fileID: 11400000, guid: 0e310aebe477bee4eba6ddcebc07f5f0, type: 2}
+  isVisible: 1
+  isTransparent: 0
   left: stone_browniron_alt
   right: stone_browniron_alt
   top: stone_browniron

--- a/blockycraft/Assets/Resources/BlockTypes/OreCoal.asset
+++ b/blockycraft/Assets/Resources/BlockTypes/OreCoal.asset
@@ -13,8 +13,9 @@ MonoBehaviour:
   m_Name: OreCoal
   m_EditorClassIdentifier: 
   blockName: Ore Coal
-  material: {fileID: 2100000, guid: 7b1043f1574203e419d8073f6a72ed8e, type: 2}
   textures: {fileID: 11400000, guid: 0e310aebe477bee4eba6ddcebc07f5f0, type: 2}
+  isVisible: 1
+  isTransparent: 0
   left: stone_coal_alt
   right: stone_coal_alt
   top: stone_coal

--- a/blockycraft/Assets/Resources/BlockTypes/OreDiamond.asset
+++ b/blockycraft/Assets/Resources/BlockTypes/OreDiamond.asset
@@ -13,8 +13,9 @@ MonoBehaviour:
   m_Name: OreDiamond
   m_EditorClassIdentifier: 
   blockName: Diamond Ore
-  material: {fileID: 2100000, guid: 7b1043f1574203e419d8073f6a72ed8e, type: 2}
   textures: {fileID: 11400000, guid: 0e310aebe477bee4eba6ddcebc07f5f0, type: 2}
+  isVisible: 1
+  isTransparent: 0
   left: stone_diamond_alt
   right: stone_diamond_alt
   top: stone_diamond

--- a/blockycraft/Assets/Resources/BlockTypes/OreGold.asset
+++ b/blockycraft/Assets/Resources/BlockTypes/OreGold.asset
@@ -13,8 +13,9 @@ MonoBehaviour:
   m_Name: OreGold
   m_EditorClassIdentifier: 
   blockName: Ore Gold
-  material: {fileID: 2100000, guid: 7b1043f1574203e419d8073f6a72ed8e, type: 2}
   textures: {fileID: 11400000, guid: 0e310aebe477bee4eba6ddcebc07f5f0, type: 2}
+  isVisible: 1
+  isTransparent: 0
   left: stone_gold_alt
   right: stone_gold_alt
   top: stone_gold

--- a/blockycraft/Assets/Resources/BlockTypes/OreIron.asset
+++ b/blockycraft/Assets/Resources/BlockTypes/OreIron.asset
@@ -13,8 +13,9 @@ MonoBehaviour:
   m_Name: OreIron
   m_EditorClassIdentifier: 
   blockName: Iron Ore
-  material: {fileID: 2100000, guid: 7b1043f1574203e419d8073f6a72ed8e, type: 2}
   textures: {fileID: 11400000, guid: 0e310aebe477bee4eba6ddcebc07f5f0, type: 2}
+  isVisible: 1
+  isTransparent: 0
   left: stone_iron_alt
   right: stone_iron_alt
   top: stone_iron

--- a/blockycraft/Assets/Resources/BlockTypes/OreSilver.asset
+++ b/blockycraft/Assets/Resources/BlockTypes/OreSilver.asset
@@ -13,8 +13,9 @@ MonoBehaviour:
   m_Name: OreSilver
   m_EditorClassIdentifier: 
   blockName: Ore Silver
-  material: {fileID: 2100000, guid: 7b1043f1574203e419d8073f6a72ed8e, type: 2}
   textures: {fileID: 11400000, guid: 0e310aebe477bee4eba6ddcebc07f5f0, type: 2}
+  isVisible: 1
+  isTransparent: 0
   left: stone_silver_alt
   right: stone_silver_alt
   top: stone_silver

--- a/blockycraft/Assets/Resources/BlockTypes/Oven.asset
+++ b/blockycraft/Assets/Resources/BlockTypes/Oven.asset
@@ -13,8 +13,9 @@ MonoBehaviour:
   m_Name: Oven
   m_EditorClassIdentifier: 
   blockName: Oven
-  material: {fileID: 2100000, guid: 7b1043f1574203e419d8073f6a72ed8e, type: 2}
   textures: {fileID: 11400000, guid: 0e310aebe477bee4eba6ddcebc07f5f0, type: 2}
+  isVisible: 1
+  isTransparent: 0
   left: stone
   right: stone
   top: stone

--- a/blockycraft/Assets/Resources/BlockTypes/Redsand.asset
+++ b/blockycraft/Assets/Resources/BlockTypes/Redsand.asset
@@ -13,8 +13,9 @@ MonoBehaviour:
   m_Name: Redsand
   m_EditorClassIdentifier: 
   blockName: Red Sand
-  material: {fileID: 2100000, guid: 7b1043f1574203e419d8073f6a72ed8e, type: 2}
   textures: {fileID: 11400000, guid: 0e310aebe477bee4eba6ddcebc07f5f0, type: 2}
+  isVisible: 1
+  isTransparent: 0
   left: redsand
   right: redsand
   top: redsand

--- a/blockycraft/Assets/Resources/BlockTypes/Redstone.asset
+++ b/blockycraft/Assets/Resources/BlockTypes/Redstone.asset
@@ -13,8 +13,9 @@ MonoBehaviour:
   m_Name: Redstone
   m_EditorClassIdentifier: 
   blockName: Redstone
-  material: {fileID: 2100000, guid: 7b1043f1574203e419d8073f6a72ed8e, type: 2}
   textures: {fileID: 11400000, guid: 0e310aebe477bee4eba6ddcebc07f5f0, type: 2}
+  isVisible: 1
+  isTransparent: 0
   left: redstone
   right: redstone
   top: redstone

--- a/blockycraft/Assets/Resources/BlockTypes/RedstoneEmerald.asset
+++ b/blockycraft/Assets/Resources/BlockTypes/RedstoneEmerald.asset
@@ -13,8 +13,9 @@ MonoBehaviour:
   m_Name: RedstoneEmerald
   m_EditorClassIdentifier: 
   blockName: Redstone Emerald
-  material: {fileID: 2100000, guid: 7b1043f1574203e419d8073f6a72ed8e, type: 2}
   textures: {fileID: 11400000, guid: 0e310aebe477bee4eba6ddcebc07f5f0, type: 2}
+  isVisible: 1
+  isTransparent: 0
   left: redstone_emerald_alt
   right: redstone_emerald_alt
   top: redstone_emerald

--- a/blockycraft/Assets/Resources/BlockTypes/RedstoneSand.asset
+++ b/blockycraft/Assets/Resources/BlockTypes/RedstoneSand.asset
@@ -13,8 +13,9 @@ MonoBehaviour:
   m_Name: RedstoneSand
   m_EditorClassIdentifier: 
   blockName: Redstone Sand
-  material: {fileID: 2100000, guid: 7b1043f1574203e419d8073f6a72ed8e, type: 2}
   textures: {fileID: 11400000, guid: 0e310aebe477bee4eba6ddcebc07f5f0, type: 2}
+  isVisible: 1
+  isTransparent: 0
   left: redstone_sand
   right: redstone_sand
   top: redsand

--- a/blockycraft/Assets/Resources/BlockTypes/Sand.asset
+++ b/blockycraft/Assets/Resources/BlockTypes/Sand.asset
@@ -13,8 +13,9 @@ MonoBehaviour:
   m_Name: Sand
   m_EditorClassIdentifier: 
   blockName: Sand
-  material: {fileID: 2100000, guid: 7b1043f1574203e419d8073f6a72ed8e, type: 2}
   textures: {fileID: 11400000, guid: 0e310aebe477bee4eba6ddcebc07f5f0, type: 2}
+  isVisible: 1
+  isTransparent: 0
   left: sand
   right: sand
   top: sand

--- a/blockycraft/Assets/Resources/BlockTypes/Snow.asset
+++ b/blockycraft/Assets/Resources/BlockTypes/Snow.asset
@@ -13,8 +13,9 @@ MonoBehaviour:
   m_Name: Snow
   m_EditorClassIdentifier: 
   blockName: Snow
-  material: {fileID: 2100000, guid: 7b1043f1574203e419d8073f6a72ed8e, type: 2}
   textures: {fileID: 11400000, guid: 0e310aebe477bee4eba6ddcebc07f5f0, type: 2}
+  isVisible: 1
+  isTransparent: 0
   left: snow
   right: snow
   top: snow

--- a/blockycraft/Assets/Resources/BlockTypes/Stone.asset
+++ b/blockycraft/Assets/Resources/BlockTypes/Stone.asset
@@ -13,8 +13,9 @@ MonoBehaviour:
   m_Name: Stone
   m_EditorClassIdentifier: 
   blockName: Stone
-  material: {fileID: 2100000, guid: 7b1043f1574203e419d8073f6a72ed8e, type: 2}
   textures: {fileID: 11400000, guid: 0e310aebe477bee4eba6ddcebc07f5f0, type: 2}
+  isVisible: 1
+  isTransparent: 0
   left: stone
   right: stone
   top: stone

--- a/blockycraft/Assets/Resources/BlockTypes/StoneDirt.asset
+++ b/blockycraft/Assets/Resources/BlockTypes/StoneDirt.asset
@@ -12,9 +12,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f4b3dcbb8f276bf4d8e1be3862f9ba27, type: 3}
   m_Name: StoneDirt
   m_EditorClassIdentifier: 
-  blockName: Stone
-  material: {fileID: 2100000, guid: 7b1043f1574203e419d8073f6a72ed8e, type: 2}
+  blockName: Dirt (Stone)
   textures: {fileID: 11400000, guid: 0e310aebe477bee4eba6ddcebc07f5f0, type: 2}
+  isVisible: 1
+  isTransparent: 0
   left: stone_dirt
   right: stone_dirt
   top: dirt

--- a/blockycraft/Assets/Resources/BlockTypes/StoneGrass.asset
+++ b/blockycraft/Assets/Resources/BlockTypes/StoneGrass.asset
@@ -12,9 +12,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f4b3dcbb8f276bf4d8e1be3862f9ba27, type: 3}
   m_Name: StoneGrass
   m_EditorClassIdentifier: 
-  blockName: Dirt
-  material: {fileID: 2100000, guid: 7b1043f1574203e419d8073f6a72ed8e, type: 2}
+  blockName: Grass (Stone)
   textures: {fileID: 11400000, guid: 0e310aebe477bee4eba6ddcebc07f5f0, type: 2}
+  isVisible: 1
+  isTransparent: 0
   left: stone_grass
   right: stone_grass
   top: grass_top

--- a/blockycraft/Assets/Resources/BlockTypes/StoneSand.asset
+++ b/blockycraft/Assets/Resources/BlockTypes/StoneSand.asset
@@ -12,9 +12,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f4b3dcbb8f276bf4d8e1be3862f9ba27, type: 3}
   m_Name: StoneSand
   m_EditorClassIdentifier: 
-  blockName: Dirt
-  material: {fileID: 2100000, guid: 7b1043f1574203e419d8073f6a72ed8e, type: 2}
+  blockName: Sand (Stone)
   textures: {fileID: 11400000, guid: 0e310aebe477bee4eba6ddcebc07f5f0, type: 2}
+  isVisible: 1
+  isTransparent: 0
   left: stone_sand
   right: stone_sand
   top: sand

--- a/blockycraft/Assets/Resources/BlockTypes/StoneSnow.asset
+++ b/blockycraft/Assets/Resources/BlockTypes/StoneSnow.asset
@@ -12,9 +12,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f4b3dcbb8f276bf4d8e1be3862f9ba27, type: 3}
   m_Name: StoneSnow
   m_EditorClassIdentifier: 
-  blockName: Dirt
-  material: {fileID: 2100000, guid: 7b1043f1574203e419d8073f6a72ed8e, type: 2}
+  blockName: Snow (Stone)
   textures: {fileID: 11400000, guid: 0e310aebe477bee4eba6ddcebc07f5f0, type: 2}
+  isVisible: 1
+  isTransparent: 0
   left: stone_snow
   right: stone_snow
   top: snow

--- a/blockycraft/Assets/Resources/BlockTypes/Table.asset
+++ b/blockycraft/Assets/Resources/BlockTypes/Table.asset
@@ -13,8 +13,9 @@ MonoBehaviour:
   m_Name: Table
   m_EditorClassIdentifier: 
   blockName: Table
-  material: {fileID: 2100000, guid: 7b1043f1574203e419d8073f6a72ed8e, type: 2}
   textures: {fileID: 11400000, guid: 0e310aebe477bee4eba6ddcebc07f5f0, type: 2}
+  isVisible: 1
+  isTransparent: 0
   left: wood
   right: wood
   top: table

--- a/blockycraft/Assets/Resources/BlockTypes/Water.asset
+++ b/blockycraft/Assets/Resources/BlockTypes/Water.asset
@@ -13,8 +13,9 @@ MonoBehaviour:
   m_Name: Water
   m_EditorClassIdentifier: 
   blockName: Water
-  material: {fileID: 2100000, guid: 7b1043f1574203e419d8073f6a72ed8e, type: 2}
   textures: {fileID: 11400000, guid: 0e310aebe477bee4eba6ddcebc07f5f0, type: 2}
+  isVisible: 1
+  isTransparent: 0
   left: water
   right: water
   top: water

--- a/blockycraft/Assets/Resources/BlockTypes/Wood.asset
+++ b/blockycraft/Assets/Resources/BlockTypes/Wood.asset
@@ -13,8 +13,9 @@ MonoBehaviour:
   m_Name: Wood
   m_EditorClassIdentifier: 
   blockName: Wood
-  material: {fileID: 2100000, guid: 7b1043f1574203e419d8073f6a72ed8e, type: 2}
   textures: {fileID: 11400000, guid: 0e310aebe477bee4eba6ddcebc07f5f0, type: 2}
+  isVisible: 1
+  isTransparent: 0
   left: wood
   right: wood
   top: wood

--- a/blockycraft/Assets/Resources/BlockTypes/WoodRed.asset
+++ b/blockycraft/Assets/Resources/BlockTypes/WoodRed.asset
@@ -13,8 +13,9 @@ MonoBehaviour:
   m_Name: WoodRed
   m_EditorClassIdentifier: 
   blockName: Red Wood
-  material: {fileID: 2100000, guid: 7b1043f1574203e419d8073f6a72ed8e, type: 2}
   textures: {fileID: 11400000, guid: 0e310aebe477bee4eba6ddcebc07f5f0, type: 2}
+  isVisible: 1
+  isTransparent: 0
   left: wood_red
   right: wood_red
   top: wood_red


### PR DESCRIPTION
Prune unused properties from BlockType assets and fix mismatched block names.

The pruning had the benefit of serializing the `isTransparent` and `isVisible` properties into the assets. Without it, the assets would take whatever the default value is.