### PR TITLE
Configure test runner for Unity project

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,6 +54,8 @@ jobs:
       - name: Run tests
         uses: webbertakken/unity-test-runner@v1.6
         if: matrix.targetPlatform == 'WebGL'
+        env:
+          UNITY_PROJECT_PATH: blockycraft/.
         with:
           unityVersion: ${{ matrix.unityVersion }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,7 @@ jobs:
         if: matrix.targetPlatform == 'WebGL'
         with:
           unityVersion: ${{ matrix.unityVersion }}
-          projectPath: blockycraft
+          projectPath: ./blockycraft/.
 
       - name: Upload tests
         uses: actions/upload-artifact@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,6 +51,13 @@ jobs:
           targetPlatform: ${{ matrix.targetPlatform }}
           buildName: blockycraft
 
+      - name: Run project tests
+        uses: webbertakken/unity-test-runner@v1.4
+        if: matrix.targetPlatform == 'StandaloneLinux64'
+        with:
+          projectPath: blockycraft/.
+          unityVersion: ${{ matrix.unityVersion }}
+
       - name: Upload to artifacts
         uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,7 @@ jobs:
         if: matrix.targetPlatform == 'WebGL'
         with:
           unityVersion: ${{ matrix.unityVersion }}
-          projectPath: ./blockycraft/.
+          projectPath: blockycraft
 
       - name: Upload tests
         uses: actions/upload-artifact@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,6 @@ jobs:
         uses: webbertakken/unity-test-runner@v1.6
         if: matrix.targetPlatform == 'WebGL'
         with:
-          projectPath: blockycraft/.
           unityVersion: ${{ matrix.unityVersion }}
 
       - name: Upload tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,12 +54,9 @@ jobs:
       - name: Run tests
         uses: webbertakken/unity-test-runner@v1.6
         if: matrix.targetPlatform == 'WebGL'
-        env:
-          UNITY_PROJECT_PATH: blockycraft/.
-          PROJECT_PATH: blockycraft/.
         with:
           unityVersion: ${{ matrix.unityVersion }}
-          projectPath: blockycraft/.
+          projectPath: blockycraft
 
       - name: Upload tests
         uses: actions/upload-artifact@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,6 +56,7 @@ jobs:
         if: matrix.targetPlatform == 'WebGL'
         env:
           UNITY_PROJECT_PATH: blockycraft/.
+          PROJECT_PATH: blockycraft/.
         with:
           unityVersion: ${{ matrix.unityVersion }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Run project tests
         uses: webbertakken/unity-test-runner@v1.4
-        if: matrix.targetPlatform == 'StandaloneLinux64'
+        if: matrix.targetPlatform == 'WebGL'
         with:
           projectPath: blockycraft/.
           unityVersion: ${{ matrix.unityVersion }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,12 +51,19 @@ jobs:
           targetPlatform: ${{ matrix.targetPlatform }}
           buildName: blockycraft
 
-      - name: Run project tests
-        uses: webbertakken/unity-test-runner@v1.4
+      - name: Run tests
+        uses: webbertakken/unity-test-runner@v1.6
         if: matrix.targetPlatform == 'WebGL'
         with:
           projectPath: blockycraft/.
           unityVersion: ${{ matrix.unityVersion }}
+
+      - name: Upload tests
+        uses: actions/upload-artifact@v1
+        if: matrix.targetPlatform == 'WebGL'
+        with:
+          name: test-results
+          path: artifacts
 
       - name: Upload to artifacts
         uses: actions/upload-artifact@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,6 +59,7 @@ jobs:
           PROJECT_PATH: blockycraft/.
         with:
           unityVersion: ${{ matrix.unityVersion }}
+          projectPath: blockycraft/.
 
       - name: Upload tests
         uses: actions/upload-artifact@v1

--- a/blockycraft/Assets/Tests/MathHelperTests.cs
+++ b/blockycraft/Assets/Tests/MathHelperTests.cs
@@ -1,0 +1,130 @@
+﻿using System.Collections.Generic;
+using Assets.Scripts;
+using NUnit.Framework;
+using NUnit.Framework.Internal;
+
+namespace Tests
+{
+    public sealed class MathHelperTests
+    {
+        public static IEnumerable<TestCaseData> WrapIterativeDataProvider()
+        {
+            var size = 8;
+            var levels = 2;
+            var iterator = new Iterator3D(size);
+            for (int level = 0; level < levels; level++)
+                foreach (var item in iterator)
+                {
+                    yield return new TestCaseData(
+                        size,
+                        item.x + level * size,
+                        item.y + level * size,
+                        item.z + level * size,
+                        item.x,
+                        item.y,
+                        item.z
+                    );
+
+                    yield return new TestCaseData(
+                        size,
+                        item.x - level * size,
+                        item.y - level * size,
+                        item.z - level * size,
+                        item.x,
+                        item.y,
+                        item.z
+                    );
+                }
+        }
+
+        [Test, TestCaseSource("WrapIterativeDataProvider")]
+        public void WrapIterative(int size, int x, int y, int z, int expectedX, int expectedY, int expectedZ)
+        {
+            var actual = MathHelper.Wrap(x, y, z, size);
+            Assert.AreEqual(expectedX, actual.x);
+            Assert.AreEqual(expectedY, actual.y);
+            Assert.AreEqual(expectedZ, actual.z);
+        }
+
+        [TestCase(8, 1, 2, 3, 1, 2, 3)]
+        [TestCase(8, 9, 10, 11, 1, 2, 3)]
+        [TestCase(8, -1, -2, -3, 7, 6, 5)]
+        [TestCase(8, -9, -10, -11, 7, 6, 5)]
+        [TestCase(8, 8, 0, 0, 0, 0, 0)]
+        [TestCase(8, 0, 8, 0, 0, 0, 0)]
+        [TestCase(8, 0, 0, 8, 0, 0, 0)]
+        [TestCase(8, 0, 0, 0, 0, 0, 0)]
+        [TestCase(8, -8, 0, 0, 0, 0, 0)]
+        [TestCase(8, 0, -8, 0, 0, 0, 0)]
+        [TestCase(8, 0, 0, -8, 0, 0, 0)]
+        public void Wrap(int size, int x, int y, int z, int expectedX, int expectedY, int expectedZ)
+        {
+            var actual = MathHelper.Wrap(x, y, z, size);
+            Assert.AreEqual(expectedX, actual.x);
+            Assert.AreEqual(expectedY, actual.y);
+            Assert.AreEqual(expectedZ, actual.z);
+        }
+
+        public static IEnumerable<TestCaseData> AnchorIterativeDataProvider()
+        {
+            var size = 8;
+            var levels = 2;
+            var iterator = new Iterator3D(size);
+            for (int level = 0; level < levels; level++)
+                foreach (var item in iterator)
+                {
+                    yield return new TestCaseData(
+                        size,
+                        level * size + item.x,
+                        level * size + item.y,
+                        level * size + item.z,
+                        level,
+                        level,
+                        level
+                    );
+
+                    yield return new TestCaseData(
+                        size,
+                        -level * size + item.x,
+                        -level * size + item.y,
+                        -level * size + item.z,
+                        -level,
+                        -level,
+                        -level
+                    );
+                }
+        }
+
+        [Test, TestCaseSource("AnchorIterativeDataProvider")]
+        public void AnchorIterative(int size, int x, int y, int z, int expectedX, int expectedY, int expectedZ)
+        {
+            var actual = MathHelper.Anchor(x, y, z, size);
+            Assert.AreEqual(expectedX, actual.x);
+            Assert.AreEqual(expectedY, actual.y);
+            Assert.AreEqual(expectedZ, actual.z);
+        }
+
+
+        [TestCase(8, 0, 0, 0, 0, 0, 0)]
+        [TestCase(8, 1, 1, 1, 0, 0, 0)]
+        [TestCase(8, -1, 0, 0, -1, 0, 0)]
+        [TestCase(8, 0, -1, 0, 0, -1, 0)]
+        [TestCase(8, 0, 0, -1, 0, 0, -1)]
+        [TestCase(8, -8, 0, 0, -1, 0, 0)]
+        [TestCase(8, 0, -8, 0, 0, -1, 0)]
+        [TestCase(8, 0, 0, -8, 0, 0, -1)]
+        [TestCase(8, -16, 0, 0, -2, 0, 0)]
+        [TestCase(8, 0, -16, 0, 0, -2, 0)]
+        [TestCase(8, 0, 0, -16, 0, 0, -2)]
+        [TestCase(8, -17, 0, 0, -3, 0, 0)]
+        [TestCase(8, 0, -17, 0, 0, -3, 0)]
+        [TestCase(8, 0, 0, -17, 0, 0, -3)]
+        public void Anchor(int size, int x, int y, int z, int expectedX, int expectedY, int expectedZ)
+        {
+            var actual = MathHelper.Anchor(x, y, z, size);
+            Assert.AreEqual(expectedX, actual.x);
+            Assert.AreEqual(expectedY, actual.y);
+            Assert.AreEqual(expectedZ, actual.z);
+        }
+    }
+}

--- a/blockycraft/Assets/Tests/MathHelperTests.cs.meta
+++ b/blockycraft/Assets/Tests/MathHelperTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e4496e4c3b668a1458d9885912e95ce5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Configure running tests when building on the linux environment.

Add a series of tests for the MathHelper to ensure that the conversion between physical and logical space is working as intended.

The tests do not run on all environments due to the increased build times. WebGL was selected as the only target platform as it is the primary deployment target (blockycraft.jrbeverly.dev/play). If tests begin to make use of execution (`UnityTest`) then this may change.