### PR TITLE
Support new simple biomes based off Perlin

### DIFF
--- a/blockycraft/Assets/Resources/Biomes/Desert.asset
+++ b/blockycraft/Assets/Resources/Biomes/Desert.asset
@@ -1,0 +1,23 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1679a2879e2937842af36c4f453aaec4, type: 3}
+  m_Name: Desert
+  m_EditorClassIdentifier: 
+  Name: Plains
+  Air: {fileID: 11400000, guid: 0cd8cdf8eb2ebd5458a0b45e89c61fe2, type: 2}
+  Bedrock: {fileID: 11400000, guid: 7ef8582028b03074eb8dd47cb5537e1b, type: 2}
+  Dirt: {fileID: 11400000, guid: 59cdc2dd76bc8de43996ac0361c1ea7d, type: 2}
+  Grass: {fileID: 11400000, guid: f11ba406ea413344396955b48d733617, type: 2}
+  Blocks: []
+  GroundHeight: 2
+  Height: 7
+  Scale: 0.3

--- a/blockycraft/Assets/Resources/Biomes/Desert.asset.meta
+++ b/blockycraft/Assets/Resources/Biomes/Desert.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cb3dc8175d11fa344beea450b0409491
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/blockycraft/Assets/Resources/Biomes/Dunes.asset
+++ b/blockycraft/Assets/Resources/Biomes/Dunes.asset
@@ -10,13 +10,13 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 1679a2879e2937842af36c4f453aaec4, type: 3}
-  m_Name: Grasslands
+  m_Name: Dunes
   m_EditorClassIdentifier: 
   Name: Grasslands
   Air: {fileID: 11400000, guid: 0cd8cdf8eb2ebd5458a0b45e89c61fe2, type: 2}
   Bedrock: {fileID: 11400000, guid: 7ef8582028b03074eb8dd47cb5537e1b, type: 2}
-  Dirt: {fileID: 11400000, guid: a8f914cd637083345854577f4a7cfd3c, type: 2}
-  Grass: {fileID: 11400000, guid: 28e59d219862508419a9db71331f0f31, type: 2}
+  Dirt: {fileID: 11400000, guid: 59cdc2dd76bc8de43996ac0361c1ea7d, type: 2}
+  Grass: {fileID: 11400000, guid: f11ba406ea413344396955b48d733617, type: 2}
   Blocks:
   - Type: {fileID: 11400000, guid: 6569cea3ef11cdf40801db7926d8f506, type: 2}
     minHeight: -100
@@ -30,6 +30,6 @@ MonoBehaviour:
     noiseOffset: 0
     scale: 0.1
     threshold: 0.5
-  GroundHeight: 2
-  Height: 5
-  Scale: 0.15
+  GroundHeight: 3
+  Height: 15
+  Scale: 0.35

--- a/blockycraft/Assets/Resources/Biomes/Dunes.asset.meta
+++ b/blockycraft/Assets/Resources/Biomes/Dunes.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f8b452e959322b448b5127a44847a248
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/blockycraft/Assets/Resources/Biomes/Hilly.asset
+++ b/blockycraft/Assets/Resources/Biomes/Hilly.asset
@@ -30,6 +30,6 @@ MonoBehaviour:
     noiseOffset: 0
     scale: 0.1
     threshold: 0.5
-  GroundHeight: 0
+  GroundHeight: 3
   Height: 15
-  Scale: 0.25
+  Scale: 0.35

--- a/blockycraft/Assets/Resources/Biomes/Plains.asset
+++ b/blockycraft/Assets/Resources/Biomes/Plains.asset
@@ -10,26 +10,14 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 1679a2879e2937842af36c4f453aaec4, type: 3}
-  m_Name: Grasslands
+  m_Name: Plains
   m_EditorClassIdentifier: 
-  Name: Grasslands
+  Name: Plains
   Air: {fileID: 11400000, guid: 0cd8cdf8eb2ebd5458a0b45e89c61fe2, type: 2}
   Bedrock: {fileID: 11400000, guid: 7ef8582028b03074eb8dd47cb5537e1b, type: 2}
   Dirt: {fileID: 11400000, guid: a8f914cd637083345854577f4a7cfd3c, type: 2}
   Grass: {fileID: 11400000, guid: 28e59d219862508419a9db71331f0f31, type: 2}
-  Blocks:
-  - Type: {fileID: 11400000, guid: 6569cea3ef11cdf40801db7926d8f506, type: 2}
-    minHeight: -100
-    maxHeight: 0
-    noiseOffset: 500
-    scale: 0.2
-    threshold: 0.6
-  - Type: {fileID: 11400000, guid: 55d6b24d6607f6a469a7270686024544, type: 2}
-    minHeight: -100
-    maxHeight: -30
-    noiseOffset: 0
-    scale: 0.1
-    threshold: 0.5
+  Blocks: []
   GroundHeight: 2
-  Height: 5
-  Scale: 0.15
+  Height: 7
+  Scale: 0.3

--- a/blockycraft/Assets/Resources/Biomes/Plains.asset.meta
+++ b/blockycraft/Assets/Resources/Biomes/Plains.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8a446c6ca0b12cf48913e824ed0fd1c5
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/blockycraft/Assets/Resources/Biomes/Sands.asset
+++ b/blockycraft/Assets/Resources/Biomes/Sands.asset
@@ -10,13 +10,13 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 1679a2879e2937842af36c4f453aaec4, type: 3}
-  m_Name: Grasslands
+  m_Name: Sands
   m_EditorClassIdentifier: 
-  Name: Grasslands
+  Name: Sands
   Air: {fileID: 11400000, guid: 0cd8cdf8eb2ebd5458a0b45e89c61fe2, type: 2}
   Bedrock: {fileID: 11400000, guid: 7ef8582028b03074eb8dd47cb5537e1b, type: 2}
   Dirt: {fileID: 11400000, guid: a8f914cd637083345854577f4a7cfd3c, type: 2}
-  Grass: {fileID: 11400000, guid: 28e59d219862508419a9db71331f0f31, type: 2}
+  Grass: {fileID: 11400000, guid: f11ba406ea413344396955b48d733617, type: 2}
   Blocks:
   - Type: {fileID: 11400000, guid: 6569cea3ef11cdf40801db7926d8f506, type: 2}
     minHeight: -100

--- a/blockycraft/Assets/Resources/Biomes/Sands.asset.meta
+++ b/blockycraft/Assets/Resources/Biomes/Sands.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6545d3b09fb31864291517429e30afc2
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/blockycraft/Assets/Scripts/Biome/Generator/PerlinWorldGenerator.cs
+++ b/blockycraft/Assets/Scripts/Biome/Generator/PerlinWorldGenerator.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 namespace Assets.Scripts.Biome.Generator
 {
-    [CreateAssetMenu(fileName = "Generator", menuName = "Blockycraft/Generators/Perlin")]
+    [CreateAssetMenu(fileName = "Biome", menuName = "Blockycraft/Biomes/Perlin")]
     public sealed class PerlinWorldGenerator : Biome
     {
         [Header("Descriptors")]


### PR DESCRIPTION
Support simple new biomes built off Perlin Noise generation.

These biomes don't have any extreme complexity, but were designed with the intention to show off more than just the grass & dirt blocks. There is a single new 'grass' biome, with three sand-based biomes that have grass equivalent. This was done with the intent to help service biome transitions.

When the API for biome generation has been ironed out, and preview options are available for biomes. I expect to increase the number of available biomes (snow, redsand, greystone, etc).