### PR TITLE
Use preview scene for the BlockType 

### DIFF
--- a/blockycraft/Assets/Editor/BlockTypeEditor.cs
+++ b/blockycraft/Assets/Editor/BlockTypeEditor.cs
@@ -3,6 +3,8 @@ using Blockycraft;
 using Blockycraft.World.Chunk;
 using UnityEditor;
 using UnityEngine;
+using UnityEditor.SceneManagement;
+using UnityEngine.SceneManagement;
 
 [CustomEditor(typeof(BlockType))]
 public class BlockTypeEditor : Editor
@@ -10,6 +12,7 @@ public class BlockTypeEditor : Editor
     public const float ANGLE = 90.0f;
 
     private PreviewRenderUtility previewRenderUtility;
+    private Scene previewScene;
     private MeshFilter targetMeshFilter;
     private MeshRenderer targetMeshRenderer;
     private GameObject previewRendererObject;
@@ -20,16 +23,19 @@ public class BlockTypeEditor : Editor
         if (previewRenderUtility != null)
             return;
 
+        previewScene = EditorSceneManager.NewPreviewScene();
         previewRenderUtility = new PreviewRenderUtility(false);
 
         previewRenderUtility.camera.transform.position = new Vector3(5, 5, 5);
         previewRenderUtility.camera.transform.LookAt(Vector3.zero, Vector3.up);
-
+        previewRenderUtility.camera.scene = previewScene;
+        
         previewRendererObject = EditorUtility.CreateGameObjectWithHideFlags(
             "Preview Object",
             HideFlags.HideAndDontSave,
             components
         );
+        SceneManager.MoveGameObjectToScene(previewRendererObject, previewScene);
 
         InitializeLighting(previewRenderUtility);
         ReloadMesh(previewRendererObject, block);

--- a/blockycraft/Assets/Scripts/Biome.meta
+++ b/blockycraft/Assets/Scripts/Biome.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 6612037f8b02c9843a1e94299c0d1345
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
Use a preview scene when rendering the preview BlockType.

This resolves the issue where the block would show in the editor scene, as the preview window was using the default scene. Switching to a temporary preview scene that will be disposed of after helps resolve this issue.