### PR TITLE
Epsilon adjustment to avoid whitespaces in render

### DIFF
--- a/blockycraft/Assets/Engine/Geometry/Voxel.cs
+++ b/blockycraft/Assets/Engine/Geometry/Voxel.cs
@@ -9,17 +9,18 @@ namespace Blockycraft.Engine.Geometry
         public const int NumberOfFaces = 6;
 
         public static readonly Vector3 Center = new Vector3(0.5f, 0.5f, 0.5f);
+        public const float Epsilon = 0.005f;
 
         public static readonly Vector3[] Vertices = new Vector3[8]
         {
-            new Vector3(0.0f, 0.0f, 0.0f),
-            new Vector3(1.0f, 0.0f, 0.0f),
-            new Vector3(1.0f, 1.0f, 0.0f),
-            new Vector3(0.0f, 1.0f, 0.0f),
-            new Vector3(0.0f, 0.0f, 1.0f),
-            new Vector3(1.0f, 0.0f, 1.0f),
-            new Vector3(1.0f, 1.0f, 1.0f),
-            new Vector3(0.0f, 1.0f, 1.0f)
+            new Vector3(0.0f - Epsilon, 0.0f - Epsilon, 0.0f - Epsilon),
+            new Vector3(1.0f + Epsilon, 0.0f - Epsilon, 0.0f - Epsilon),
+            new Vector3(1.0f + Epsilon, 1.0f + Epsilon, 0.0f - Epsilon),
+            new Vector3(0.0f - Epsilon, 1.0f + Epsilon, 0.0f - Epsilon),
+            new Vector3(0.0f - Epsilon, 0.0f - Epsilon, 1.0f + Epsilon),
+            new Vector3(1.0f + Epsilon, 0.0f - Epsilon, 1.0f + Epsilon),
+            new Vector3(1.0f + Epsilon, 1.0f + Epsilon, 1.0f + Epsilon),
+            new Vector3(0.0f - Epsilon, 1.0f + Epsilon, 1.0f + Epsilon)
         };
 
         public static readonly int[] Triangles = new int[6]{


### PR DESCRIPTION
Increase the size of each individual block to be larger than 1 to avoid whitespace clipping.

Currently from a distance there is a whitespace that appears between the blocks. This is due to how floating point numbers work in game engines like Unity (and in general). Since the calculations are floating, there are times when the blocks will not overlap exactly.

By padding each of the blocks, we ensure that at least within a certain range the blocks will not have this effect.