### PR TITLE
Generate chunks in the world based on distance to player

### DIFF
--- a/blockycraft/Assets/Scripts/Behaviours/World.cs
+++ b/blockycraft/Assets/Scripts/Behaviours/World.cs
@@ -7,6 +7,7 @@ using UnityEngine;
 public sealed class World : MonoBehaviour
 {
     public const int SIZE = 16;
+    public const int STARTUP_PROCESSED_CHUNKS = 16;
     public Material material;
 
     private Space3D<Chunk> chunks;
@@ -90,14 +91,14 @@ public sealed class World : MonoBehaviour
 
     private void Start()
     {
-        radius = new Vector3Int(8, 3, 8);
+        radius = new Vector3Int(16, 3, 16);
         chunks = new Space3D<Chunk>();
         chunkBlocks = new Space3D<ChunkBlocks>();
         factory = new ChunkFactory();
         current = start;
 
         Ping(player.WhereAmI());
-        while (factory.Process()) { }
+        for (int i = 0; i < STARTUP_PROCESSED_CHUNKS; i++) factory.Process(player.WhereAmI());
     }
 
     private void UpdateChunks()
@@ -118,7 +119,7 @@ public sealed class World : MonoBehaviour
 
     private void Update()
     {
-        factory.Process();
+        factory.Process(player.WhereAmI());
 
         UpdateChunks();
 


### PR DESCRIPTION
Generate chunks based on proximity to player to ensure there is always a visible element.

When the chunk factory is looking for the next work item, it will now search for the closest chunk to the player. This is done with the `WhereAmI` lookup that finds the chunk the player is currently in.

The algorithm for finding the nearest point is the brute force implementation. A more efficient tree structure would be needed (such as a BkTree) to improve the performance. As the Space3D interface evolves, I expect at some point I will make the decision to implement a space partition data structure better suited for the API workload.