### PR TITLE
Simplify the Player movement code, improving control

### DIFF
--- a/blockycraft/Assets/Scenes/Blockycraft.unity
+++ b/blockycraft/Assets/Scenes/Blockycraft.unity
@@ -220,6 +220,74 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
+--- !u!1 &47591550
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 47591551}
+  - component: {fileID: 47591552}
+  - component: {fileID: 47591553}
+  m_Layer: 0
+  m_Name: Player
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &47591551
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 47591550}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 20, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 963194228}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &47591552
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 47591550}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a160e08734e56b6449a8686324af1b06, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  world: {fileID: 1112436241}
+  cam: {fileID: 963194228}
+  highlightBlock: {fileID: 1551536749}
+  placeBlock: {fileID: 1691497281}
+  air: {fileID: 11400000, guid: 0cd8cdf8eb2ebd5458a0b45e89c61fe2, type: 2}
+  selector: {fileID: 47591553}
+  increment: 0.1
+  reach: 7
+  speed: 5
+--- !u!114 &47591553
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 47591550}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1e032a37f6c23a947acf6bc9db8869f9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Image: {fileID: 508692941}
+  DefaultKey: Grass (Dirt)
 --- !u!1 &332818875
 GameObject:
   m_ObjectHideFlags: 0
@@ -487,8 +555,6 @@ GameObject:
   - component: {fileID: 963194228}
   - component: {fileID: 963194227}
   - component: {fileID: 963194226}
-  - component: {fileID: 963194229}
-  - component: {fileID: 963194230}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -554,48 +620,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 963194225}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 25, z: -10}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 1.8, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 0}
+  m_Father: {fileID: 47591551}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &963194229
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 963194225}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a160e08734e56b6449a8686324af1b06, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  world: {fileID: 1112436241}
-  cam: {fileID: 963194228}
-  highlightBlock: {fileID: 1551536749}
-  placeBlock: {fileID: 1691497281}
-  air: {fileID: 11400000, guid: 0cd8cdf8eb2ebd5458a0b45e89c61fe2, type: 2}
-  selector: {fileID: 963194230}
-  checkIncrement: 0.1
-  reach: 8
---- !u!114 &963194230
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 963194225}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1e032a37f6c23a947acf6bc9db8869f9, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  Index: 0
-  Image: {fileID: 508692941}
-  DefaultKey: Grass (Dirt)
 --- !u!1 &993907763
 GameObject:
   m_ObjectHideFlags: 0
@@ -706,7 +737,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   material: {fileID: 2100000, guid: 7b1043f1574203e419d8073f6a72ed8e, type: 2}
-  player: {fileID: 963194229}
+  player: {fileID: 47591552}
   start: {fileID: 11400000, guid: 1ef1eb461201b934f92e99e95e3235bb, type: 2}
 --- !u!1 &1281086788
 GameObject:

--- a/blockycraft/Assets/Scripts/Behaviours/Player.cs
+++ b/blockycraft/Assets/Scripts/Behaviours/Player.cs
@@ -33,18 +33,18 @@ public sealed class Player : MonoBehaviour
         if (Input.GetKeyDown(KeyCode.Space)) isClimbing = true;
         if (Input.GetKeyUp(KeyCode.Space)) isClimbing = false;
 
-        var velocity = CalculateHorizontalVelocity(horizontal, vertical);
-        if (isFalling) velocity += Vector3.down * Time.fixedDeltaTime * speed;
-        if (isClimbing) velocity += Vector3.up * Time.fixedDeltaTime * speed;
+        var velocity = CalculateVelocity(horizontal, vertical, (isFalling) ? -1 : (isClimbing) ? 1 : 0);
 
         transform.Rotate(Vector3.up * mouseHorizontal);
         cam.Rotate(Vector3.right * -mouseVertical);
         transform.Translate(velocity, Space.World);
     }
 
-    private Vector3 CalculateHorizontalVelocity(float horizontal, float vertical)
+    private Vector3 CalculateVelocity(float horizontal, float depth, float vertical)
     {
-        return ((transform.forward * vertical) + (transform.right * horizontal)) * Time.fixedDeltaTime * speed;
+        return ((transform.forward * depth) +
+                (transform.right * horizontal) +
+                (transform.up * vertical)) * Time.fixedDeltaTime * speed;
     }
 
     public Vector3Int Chunk()

--- a/blockycraft/Assets/Scripts/Behaviours/World.cs
+++ b/blockycraft/Assets/Scripts/Behaviours/World.cs
@@ -53,6 +53,17 @@ public sealed class World : MonoBehaviour
         return type;
     }
 
+    public bool HasBlock(float x, float y, float z)
+    {
+        return HasBlock(Mathf.RoundToInt(x), Mathf.RoundToInt(y), Mathf.RoundToInt(z));
+    }
+
+    public bool HasBlock(int x, int y, int z)
+    {
+        var type = GetBlock(x, y, z);
+        return type != null && type.isVisible;
+    }
+
     public static string Key(int x, int y, int z)
     {
         return $"{x}:{y}:{z}";
@@ -97,8 +108,8 @@ public sealed class World : MonoBehaviour
         factory = new ChunkFactory();
         current = start;
 
-        Ping(player.WhereAmI());
-        for (int i = 0; i < STARTUP_PROCESSED_CHUNKS; i++) factory.Process(player.WhereAmI());
+        Ping(player.Chunk());
+        for (int i = 0; i < STARTUP_PROCESSED_CHUNKS; i++) factory.Process(player.Chunk());
     }
 
     private void UpdateChunks()
@@ -119,10 +130,10 @@ public sealed class World : MonoBehaviour
 
     private void Update()
     {
-        factory.Process(player.WhereAmI());
+        factory.Process(player.Chunk());
 
         UpdateChunks();
 
-        Ping(player.WhereAmI());
+        Ping(player.Chunk());
     }
 }


### PR DESCRIPTION
Restructure main camera & player to have better movement controls for the scene.

The old movement controls had issues with navigation when trying to explore the scene. The movement direction was based on where the camera was looking. This meant that something like a 'fly-over' wasn't really possible.

This new change allows a better range of motion when flying over the biomes.