### PR TITLE
Mark the alt leaves transparent

### DIFF
--- a/blockycraft/Assets/Resources/BlockTypes/LeavesAlt.asset
+++ b/blockycraft/Assets/Resources/BlockTypes/LeavesAlt.asset
@@ -16,7 +16,7 @@ MonoBehaviour:
   preview: {fileID: 2800000, guid: 14823cfa7fc0c474c84750f75b25f242, type: 3}
   textures: {fileID: 11400000, guid: 0e310aebe477bee4eba6ddcebc07f5f0, type: 2}
   isVisible: 1
-  isTransparent: 0
+  isTransparent: 1
   left: leaves_transparent
   right: leaves_transparent
   top: leaves_transparent

--- a/blockycraft/Assets/Resources/BlockTypes/LeavesOrangeAlt.asset
+++ b/blockycraft/Assets/Resources/BlockTypes/LeavesOrangeAlt.asset
@@ -16,7 +16,7 @@ MonoBehaviour:
   preview: {fileID: 2800000, guid: b2946a969b5221d41be346e05b193d61, type: 3}
   textures: {fileID: 11400000, guid: 0e310aebe477bee4eba6ddcebc07f5f0, type: 2}
   isVisible: 1
-  isTransparent: 0
+  isTransparent: 1
   left: leaves_orange_transparent
   right: leaves_orange_transparent
   top: leaves_orange_transparent


### PR DESCRIPTION
The alternative transparent leave block types are not marked as transparent.

This causes a bit of a graphical issue when placing these blocks down. As the other blocks believe them to obscure face visibility.