### PR TITLE
Shrink the WebGL player size to better fit on smaller screens

### DIFF
--- a/blockycraft/ProjectSettings/ProjectSettings.asset
+++ b/blockycraft/ProjectSettings/ProjectSettings.asset
@@ -44,8 +44,8 @@ PlayerSettings:
   m_HolographicTrackingLossScreen: {fileID: 0}
   defaultScreenWidth: 1024
   defaultScreenHeight: 768
-  defaultScreenWidthWeb: 1920
-  defaultScreenHeightWeb: 1200
+  defaultScreenWidthWeb: 1600
+  defaultScreenHeightWeb: 900
   m_StereoRenderingPath: 0
   m_ActiveColorSpace: 0
   m_MTRendering: 1
@@ -570,7 +570,7 @@ PlayerSettings:
   webGLDebugSymbols: 0
   webGLEmscriptenArgs: 
   webGLModulesDirectory: 
-  webGLTemplate: APPLICATION:Minimal
+  webGLTemplate: APPLICATION:Default
   webGLAnalyzeBuildSize: 0
   webGLUseEmbeddedResources: 0
   webGLCompressionFormat: 1


### PR DESCRIPTION
Shrink the WebGL player size to better fit on smaller screens

At the current resolution, on smaller screens (like a laptop), the WebGL player is too large.