### PR TITLE
Replace biome per chunk with a region model

### DIFF
--- a/blockycraft/Assets/Editor/BlockTypeEditor.cs
+++ b/blockycraft/Assets/Editor/BlockTypeEditor.cs
@@ -14,13 +14,13 @@ public class BlockTypeEditor : Editor
     public const float ANGLE = 90.0f;
 
     private PreviewRenderUtility previewRenderUtility;
-    private static Scene previewScene;
+    private Scene previewScene;
     private MeshFilter targetMeshFilter;
     private MeshRenderer targetMeshRenderer;
     private GameObject previewRendererObject;
     private readonly System.Type[] components = new System.Type[] { typeof(MeshRenderer), typeof(MeshFilter) };
 
-    private void Initialize()
+    private void Initialize(BlockType type)
     {
         if (previewRenderUtility != null)
             return;
@@ -43,6 +43,8 @@ public class BlockTypeEditor : Editor
         previewRendererObject.transform.position = -Voxel.Center;
 
         InitializeLighting(previewRenderUtility);
+
+        ReloadMesh(previewRendererObject, type);
     }
 
     private void InitializeLighting(PreviewRenderUtility utility)
@@ -143,8 +145,8 @@ public class BlockTypeEditor : Editor
         if (!block.IsValid())
             return false;
 
-        Initialize();
-        ReloadMesh(previewRendererObject, (BlockType)target);
+        Initialize(block);
+       
         return true;
     }
 
@@ -199,5 +201,6 @@ public class BlockTypeEditor : Editor
     {
         previewRenderUtility?.Cleanup();
         EditorSceneManager.ClosePreviewScene(previewScene);
+        previewRenderUtility = null;
     }
 }

--- a/blockycraft/Assets/Resources/Biomes/Mountains.asset
+++ b/blockycraft/Assets/Resources/Biomes/Mountains.asset
@@ -10,17 +10,15 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 1679a2879e2937842af36c4f453aaec4, type: 3}
-  m_Name: Sands
+  m_Name: Mountains
   m_EditorClassIdentifier: 
-  Name: Sands
+  Name: Mountains
   Air: {fileID: 11400000, guid: 0cd8cdf8eb2ebd5458a0b45e89c61fe2, type: 2}
   Transitions:
-  - {fileID: 11400000, guid: cb3dc8175d11fa344beea450b0409491, type: 2}
-  - {fileID: 11400000, guid: f8b452e959322b448b5127a44847a248, type: 2}
-  - {fileID: 11400000, guid: 1ef1eb461201b934f92e99e95e3235bb, type: 2}
-  Surface: {fileID: 11400000, guid: 2a9aecd86d2fc6d48a8de270fe00a499, type: 2}
-  Substratum: {fileID: 11400000, guid: 7ef8582028b03074eb8dd47cb5537e1b, type: 2}
-  Subsoil: {fileID: 11400000, guid: 59cdc2dd76bc8de43996ac0361c1ea7d, type: 2}
+  - {fileID: 11400000, guid: e476856728ba058469d7b77933bca4b6, type: 2}
+  Surface: {fileID: 11400000, guid: 28e59d219862508419a9db71331f0f31, type: 2}
+  Substratum: {fileID: 11400000, guid: 0c955e61c7b02654993650d1fea535d6, type: 2}
+  Subsoil: {fileID: 11400000, guid: 7ef8582028b03074eb8dd47cb5537e1b, type: 2}
   Blocks:
   - Type: {fileID: 11400000, guid: 6569cea3ef11cdf40801db7926d8f506, type: 2}
     minHeight: -100
@@ -34,6 +32,6 @@ MonoBehaviour:
     noiseOffset: 0
     scale: 0.1
     threshold: 0.5
-  GroundHeight: 2
-  Height: 5
+  GroundHeight: 3
+  Height: 15
   Scale: 0.3

--- a/blockycraft/Assets/Resources/Biomes/Mountains.asset
+++ b/blockycraft/Assets/Resources/Biomes/Mountains.asset
@@ -16,7 +16,7 @@ MonoBehaviour:
   Air: {fileID: 11400000, guid: 0cd8cdf8eb2ebd5458a0b45e89c61fe2, type: 2}
   Transitions:
   - {fileID: 11400000, guid: e476856728ba058469d7b77933bca4b6, type: 2}
-  Surface: {fileID: 11400000, guid: 28e59d219862508419a9db71331f0f31, type: 2}
+  Surface: {fileID: 11400000, guid: 2a9aecd86d2fc6d48a8de270fe00a499, type: 2}
   Substratum: {fileID: 11400000, guid: 0c955e61c7b02654993650d1fea535d6, type: 2}
   Subsoil: {fileID: 11400000, guid: 7ef8582028b03074eb8dd47cb5537e1b, type: 2}
   Blocks:

--- a/blockycraft/Assets/Resources/Biomes/Mountains.asset.meta
+++ b/blockycraft/Assets/Resources/Biomes/Mountains.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 559632b9301a59745b98a5a673e0d65b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/blockycraft/Assets/Resources/Biomes/Snows.asset
+++ b/blockycraft/Assets/Resources/Biomes/Snows.asset
@@ -17,7 +17,7 @@ MonoBehaviour:
   Transitions:
   - {fileID: 11400000, guid: 559632b9301a59745b98a5a673e0d65b, type: 2}
   - {fileID: 11400000, guid: 86a7014280421f54291d2fa491f95b0b, type: 2}
-  Surface: {fileID: 11400000, guid: 2a9aecd86d2fc6d48a8de270fe00a499, type: 2}
+  Surface: {fileID: 11400000, guid: 5853ceb84440137468bebebb4e57556f, type: 2}
   Substratum: {fileID: 11400000, guid: 0c955e61c7b02654993650d1fea535d6, type: 2}
   Subsoil: {fileID: 11400000, guid: d48715b848e5f834f8548ba832df83e2, type: 2}
   Blocks: []

--- a/blockycraft/Assets/Resources/Biomes/Snows.asset
+++ b/blockycraft/Assets/Resources/Biomes/Snows.asset
@@ -1,0 +1,26 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1679a2879e2937842af36c4f453aaec4, type: 3}
+  m_Name: Snows
+  m_EditorClassIdentifier: 
+  Name: Snows
+  Air: {fileID: 11400000, guid: 0cd8cdf8eb2ebd5458a0b45e89c61fe2, type: 2}
+  Transitions:
+  - {fileID: 11400000, guid: 559632b9301a59745b98a5a673e0d65b, type: 2}
+  - {fileID: 11400000, guid: 86a7014280421f54291d2fa491f95b0b, type: 2}
+  Surface: {fileID: 11400000, guid: 2a9aecd86d2fc6d48a8de270fe00a499, type: 2}
+  Substratum: {fileID: 11400000, guid: 0c955e61c7b02654993650d1fea535d6, type: 2}
+  Subsoil: {fileID: 11400000, guid: 7ef8582028b03074eb8dd47cb5537e1b, type: 2}
+  Blocks: []
+  GroundHeight: 2
+  Height: 7
+  Scale: 0.3

--- a/blockycraft/Assets/Resources/Biomes/Snows.asset
+++ b/blockycraft/Assets/Resources/Biomes/Snows.asset
@@ -19,7 +19,7 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 86a7014280421f54291d2fa491f95b0b, type: 2}
   Surface: {fileID: 11400000, guid: 2a9aecd86d2fc6d48a8de270fe00a499, type: 2}
   Substratum: {fileID: 11400000, guid: 0c955e61c7b02654993650d1fea535d6, type: 2}
-  Subsoil: {fileID: 11400000, guid: 7ef8582028b03074eb8dd47cb5537e1b, type: 2}
+  Subsoil: {fileID: 11400000, guid: d48715b848e5f834f8548ba832df83e2, type: 2}
   Blocks: []
   GroundHeight: 2
   Height: 7

--- a/blockycraft/Assets/Resources/Biomes/Snows.asset.meta
+++ b/blockycraft/Assets/Resources/Biomes/Snows.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e476856728ba058469d7b77933bca4b6
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/blockycraft/Assets/Resources/Biomes/Tundra.asset
+++ b/blockycraft/Assets/Resources/Biomes/Tundra.asset
@@ -10,17 +10,16 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 1679a2879e2937842af36c4f453aaec4, type: 3}
-  m_Name: Sands
+  m_Name: Tundra
   m_EditorClassIdentifier: 
-  Name: Sands
+  Name: Tundra
   Air: {fileID: 11400000, guid: 0cd8cdf8eb2ebd5458a0b45e89c61fe2, type: 2}
   Transitions:
-  - {fileID: 11400000, guid: cb3dc8175d11fa344beea450b0409491, type: 2}
-  - {fileID: 11400000, guid: f8b452e959322b448b5127a44847a248, type: 2}
+  - {fileID: 11400000, guid: e476856728ba058469d7b77933bca4b6, type: 2}
   - {fileID: 11400000, guid: 1ef1eb461201b934f92e99e95e3235bb, type: 2}
   Surface: {fileID: 11400000, guid: 2a9aecd86d2fc6d48a8de270fe00a499, type: 2}
-  Substratum: {fileID: 11400000, guid: 7ef8582028b03074eb8dd47cb5537e1b, type: 2}
-  Subsoil: {fileID: 11400000, guid: 59cdc2dd76bc8de43996ac0361c1ea7d, type: 2}
+  Substratum: {fileID: 11400000, guid: 0c955e61c7b02654993650d1fea535d6, type: 2}
+  Subsoil: {fileID: 11400000, guid: 7ef8582028b03074eb8dd47cb5537e1b, type: 2}
   Blocks:
   - Type: {fileID: 11400000, guid: 6569cea3ef11cdf40801db7926d8f506, type: 2}
     minHeight: -100

--- a/blockycraft/Assets/Resources/Biomes/Tundra.asset
+++ b/blockycraft/Assets/Resources/Biomes/Tundra.asset
@@ -16,7 +16,7 @@ MonoBehaviour:
   Air: {fileID: 11400000, guid: 0cd8cdf8eb2ebd5458a0b45e89c61fe2, type: 2}
   Transitions:
   - {fileID: 11400000, guid: e476856728ba058469d7b77933bca4b6, type: 2}
-  - {fileID: 11400000, guid: 1ef1eb461201b934f92e99e95e3235bb, type: 2}
+  - {fileID: 11400000, guid: 444bcf2341baf7d46aadabac0d914230, type: 2}
   Surface: {fileID: 11400000, guid: 2a9aecd86d2fc6d48a8de270fe00a499, type: 2}
   Substratum: {fileID: 11400000, guid: 0c955e61c7b02654993650d1fea535d6, type: 2}
   Subsoil: {fileID: 11400000, guid: 7ef8582028b03074eb8dd47cb5537e1b, type: 2}

--- a/blockycraft/Assets/Resources/Biomes/Tundra.asset.meta
+++ b/blockycraft/Assets/Resources/Biomes/Tundra.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 86a7014280421f54291d2fa491f95b0b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/blockycraft/Assets/Scenes/Blockycraft.unity
+++ b/blockycraft/Assets/Scenes/Blockycraft.unity
@@ -273,7 +273,8 @@ MonoBehaviour:
   selector: {fileID: 47591553}
   increment: 0.1
   reach: 7
-  speed: 5
+  speed: 10
+  factor: 1.25
 --- !u!114 &47591553
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/blockycraft/Assets/Scripts/Behaviours/Player.cs
+++ b/blockycraft/Assets/Scripts/Behaviours/Player.cs
@@ -12,8 +12,13 @@ public sealed class Player : MonoBehaviour
     public float increment;
     public float reach;
     public float speed;
+    public float factor;
+
     private bool isFalling;
     private bool isClimbing;
+    private float mouseHorizontal;
+    private float mouseVertical;
+    private Vector3 velocity;
 
     private void Start()
     {
@@ -22,26 +27,31 @@ public sealed class Player : MonoBehaviour
 
     private void Update()
     {
-        UpdateActionBlock();
-        ProcessActions();
-    }
-
-    private void FixedUpdate()
-    {
         var horizontal = Input.GetAxis("Horizontal");
         var vertical = Input.GetAxis("Vertical");
-        var mouseHorizontal = Input.GetAxis("Mouse X");
-        var mouseVertical = Input.GetAxis("Mouse Y");
+        mouseHorizontal = Input.GetAxis("Mouse X");
+        mouseVertical = Input.GetAxis("Mouse Y");
 
         if (Input.GetKeyDown(KeyCode.LeftShift)) isFalling = true;
         if (Input.GetKeyUp(KeyCode.LeftShift)) isFalling = false;
         if (Input.GetKeyDown(KeyCode.Space)) isClimbing = true;
         if (Input.GetKeyUp(KeyCode.Space)) isClimbing = false;
 
-        var velocity = CalculateVelocity(horizontal, vertical, (isFalling) ? -1 : (isClimbing) ? 1 : 0);
+        float value = 0f;
+        if (isClimbing && isFalling) value = 0f;
+        else if (isClimbing) value = 1f;
+        else if (isFalling) value = -1f;
 
-        transform.Rotate(Vector3.up * mouseHorizontal);
-        cam.Rotate(Vector3.right * -mouseVertical);
+        velocity = CalculateVelocity(horizontal, vertical, value);
+
+        UpdateActionBlock();
+        ProcessActions();
+    }
+
+    private void FixedUpdate()
+    {
+        transform.Rotate(Vector3.up * mouseHorizontal * factor);
+        cam.Rotate(Vector3.right * -mouseVertical * factor);
         transform.Translate(velocity, Space.World);
     }
 


### PR DESCRIPTION
Biome generation defined as per region, a NxN grid of chunks, rather than per chunk.

Transitioning between the biomes is still pretty chaotic, but by adding regions it leaves more opportunity for each of the biomes to demonstrate themselves.

Snow biomes have been introduced in this, as well as some bug fixes to the player movement.