### PR TITLE
Fit WebGL onto laptop screens

### DIFF
--- a/blockycraft/ProjectSettings/ProjectSettings.asset
+++ b/blockycraft/ProjectSettings/ProjectSettings.asset
@@ -44,8 +44,8 @@ PlayerSettings:
   m_HolographicTrackingLossScreen: {fileID: 0}
   defaultScreenWidth: 1024
   defaultScreenHeight: 768
-  defaultScreenWidthWeb: 1600
-  defaultScreenHeightWeb: 900
+  defaultScreenWidthWeb: 1200
+  defaultScreenHeightWeb: 675
   m_StereoRenderingPath: 0
   m_ActiveColorSpace: 0
   m_MTRendering: 1


### PR DESCRIPTION
Reduce the size of the WebGL interface to work with laptop screens.

The previous reduction was not sufficient, and I need to reduce it again.