### PR TITLE
Increase the size of biome regions

### DIFF
--- a/blockycraft/Assets/Resources/Biomes/Desert.asset
+++ b/blockycraft/Assets/Resources/Biomes/Desert.asset
@@ -20,7 +20,19 @@ MonoBehaviour:
   Surface: {fileID: 11400000, guid: f11ba406ea413344396955b48d733617, type: 2}
   Substratum: {fileID: 11400000, guid: 7ef8582028b03074eb8dd47cb5537e1b, type: 2}
   Subsoil: {fileID: 11400000, guid: 59cdc2dd76bc8de43996ac0361c1ea7d, type: 2}
-  Blocks: []
+  Blocks:
+  - Type: {fileID: 11400000, guid: 6569cea3ef11cdf40801db7926d8f506, type: 2}
+    minHeight: -100
+    maxHeight: 0
+    noiseOffset: 500
+    scale: 0.2
+    threshold: 0.6
+  - Type: {fileID: 11400000, guid: 55d6b24d6607f6a469a7270686024544, type: 2}
+    minHeight: -100
+    maxHeight: -30
+    noiseOffset: 0
+    scale: 0.1
+    threshold: 0.5
   GroundHeight: 2
   Height: 7
   Scale: 0.3

--- a/blockycraft/Assets/Resources/Biomes/Dunes.asset
+++ b/blockycraft/Assets/Resources/Biomes/Dunes.asset
@@ -20,18 +20,18 @@ MonoBehaviour:
   Substratum: {fileID: 11400000, guid: 7ef8582028b03074eb8dd47cb5537e1b, type: 2}
   Subsoil: {fileID: 11400000, guid: 59cdc2dd76bc8de43996ac0361c1ea7d, type: 2}
   Blocks:
-  - Type: {fileID: 11400000, guid: 6569cea3ef11cdf40801db7926d8f506, type: 2}
+  - Type: {fileID: 11400000, guid: 114c54930327c9942b8d4ac82f628a48, type: 2}
     minHeight: -100
     maxHeight: 0
     noiseOffset: 500
     scale: 0.2
     threshold: 0.6
-  - Type: {fileID: 11400000, guid: 55d6b24d6607f6a469a7270686024544, type: 2}
+  - Type: {fileID: 11400000, guid: fac95a678be265a47a9ce71e81bfce8e, type: 2}
     minHeight: -100
     maxHeight: -30
     noiseOffset: 0
     scale: 0.1
     threshold: 0.5
-  GroundHeight: 3
-  Height: 15
-  Scale: 0.3
+  GroundHeight: 1
+  Height: 9
+  Scale: 0.9

--- a/blockycraft/Assets/Resources/Biomes/Grasslands.asset
+++ b/blockycraft/Assets/Resources/Biomes/Grasslands.asset
@@ -21,7 +21,7 @@ MonoBehaviour:
   Substratum: {fileID: 11400000, guid: 7ef8582028b03074eb8dd47cb5537e1b, type: 2}
   Subsoil: {fileID: 11400000, guid: a8f914cd637083345854577f4a7cfd3c, type: 2}
   Blocks:
-  - Type: {fileID: 11400000, guid: 6569cea3ef11cdf40801db7926d8f506, type: 2}
+  - Type: {fileID: 11400000, guid: 0cd8cdf8eb2ebd5458a0b45e89c61fe2, type: 2}
     minHeight: -100
     maxHeight: 0
     noiseOffset: 500

--- a/blockycraft/Assets/Resources/Biomes/Hilly.asset
+++ b/blockycraft/Assets/Resources/Biomes/Hilly.asset
@@ -20,7 +20,7 @@ MonoBehaviour:
   Substratum: {fileID: 11400000, guid: 7ef8582028b03074eb8dd47cb5537e1b, type: 2}
   Subsoil: {fileID: 11400000, guid: a8f914cd637083345854577f4a7cfd3c, type: 2}
   Blocks:
-  - Type: {fileID: 11400000, guid: 6569cea3ef11cdf40801db7926d8f506, type: 2}
+  - Type: {fileID: 11400000, guid: 55d6b24d6607f6a469a7270686024544, type: 2}
     minHeight: -100
     maxHeight: 0
     noiseOffset: 500
@@ -32,6 +32,6 @@ MonoBehaviour:
     noiseOffset: 0
     scale: 0.1
     threshold: 0.5
-  GroundHeight: 3
+  GroundHeight: 6
   Height: 15
   Scale: 0.3

--- a/blockycraft/Assets/Resources/Biomes/Mountains.asset
+++ b/blockycraft/Assets/Resources/Biomes/Mountains.asset
@@ -20,18 +20,18 @@ MonoBehaviour:
   Substratum: {fileID: 11400000, guid: 0c955e61c7b02654993650d1fea535d6, type: 2}
   Subsoil: {fileID: 11400000, guid: 7ef8582028b03074eb8dd47cb5537e1b, type: 2}
   Blocks:
-  - Type: {fileID: 11400000, guid: 6569cea3ef11cdf40801db7926d8f506, type: 2}
+  - Type: {fileID: 11400000, guid: fbad45f8c3c84e7408855d44797f85ad, type: 2}
     minHeight: -100
     maxHeight: 0
     noiseOffset: 500
     scale: 0.2
-    threshold: 0.6
-  - Type: {fileID: 11400000, guid: 55d6b24d6607f6a469a7270686024544, type: 2}
+    threshold: 0.8
+  - Type: {fileID: 11400000, guid: 8729df98ddd09b2449b169dfe2eb2851, type: 2}
     minHeight: -100
     maxHeight: -30
-    noiseOffset: 0
+    noiseOffset: 200
     scale: 0.1
-    threshold: 0.5
+    threshold: 0.2
   GroundHeight: 10
   Height: 20
   Scale: 0.7

--- a/blockycraft/Assets/Resources/Biomes/Mountains.asset
+++ b/blockycraft/Assets/Resources/Biomes/Mountains.asset
@@ -32,6 +32,6 @@ MonoBehaviour:
     noiseOffset: 0
     scale: 0.1
     threshold: 0.5
-  GroundHeight: 3
-  Height: 15
-  Scale: 0.3
+  GroundHeight: 10
+  Height: 20
+  Scale: 0.7

--- a/blockycraft/Assets/Resources/Biomes/Plains.asset
+++ b/blockycraft/Assets/Resources/Biomes/Plains.asset
@@ -20,7 +20,19 @@ MonoBehaviour:
   Surface: {fileID: 11400000, guid: 28e59d219862508419a9db71331f0f31, type: 2}
   Substratum: {fileID: 11400000, guid: 7ef8582028b03074eb8dd47cb5537e1b, type: 2}
   Subsoil: {fileID: 11400000, guid: a8f914cd637083345854577f4a7cfd3c, type: 2}
-  Blocks: []
+  Blocks:
+  - Type: {fileID: 11400000, guid: 6569cea3ef11cdf40801db7926d8f506, type: 2}
+    minHeight: -100
+    maxHeight: 0
+    noiseOffset: 500
+    scale: 0.2
+    threshold: 0.6
+  - Type: {fileID: 11400000, guid: 55d6b24d6607f6a469a7270686024544, type: 2}
+    minHeight: -100
+    maxHeight: -30
+    noiseOffset: 0
+    scale: 0.1
+    threshold: 0.5
   GroundHeight: 2
   Height: 7
   Scale: 0.3

--- a/blockycraft/Assets/Resources/Biomes/Snows.asset
+++ b/blockycraft/Assets/Resources/Biomes/Snows.asset
@@ -20,7 +20,19 @@ MonoBehaviour:
   Surface: {fileID: 11400000, guid: 5853ceb84440137468bebebb4e57556f, type: 2}
   Substratum: {fileID: 11400000, guid: 0c955e61c7b02654993650d1fea535d6, type: 2}
   Subsoil: {fileID: 11400000, guid: d48715b848e5f834f8548ba832df83e2, type: 2}
-  Blocks: []
+  Blocks:
+  - Type: {fileID: 11400000, guid: 2a40330d0d5e7a04788a872ae9b2e91c, type: 2}
+    minHeight: -100
+    maxHeight: 0
+    noiseOffset: 500
+    scale: 0.5
+    threshold: 0.8
+  - Type: {fileID: 11400000, guid: 3f04780139987614caa702665f3523df, type: 2}
+    minHeight: -100
+    maxHeight: -30
+    noiseOffset: 0
+    scale: 0.1
+    threshold: 0.5
   GroundHeight: 2
-  Height: 7
-  Scale: 0.3
+  Height: 9
+  Scale: 0.5

--- a/blockycraft/Assets/Scripts/Behaviours/World.cs
+++ b/blockycraft/Assets/Scripts/Behaviours/World.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 public sealed class World : MonoBehaviour
 {
     public const int SIZE = 16;
-    public const int REGION = 4;
+    public const int REGION = 8;
     public const int STARTUP_PROCESSED_CHUNKS = 16;
 
     private Space3D<Chunk> chunks;


### PR DESCRIPTION
Increase the size of the biome regions, increasing size of heights.

The block sampling for under ground height have been updated for all biomes to include a more diverse collection of blocks.