### PR TITLE
Remove extra files from release bundles

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -156,7 +156,7 @@ jobs:
 
     - name: Package artifact for release
       run: |
-        zip -v -r ../${{ matrix.targetPlatform }}.zip .* *
+        zip -v -r ../${{ matrix.targetPlatform }}.zip *
       working-directory: artifacts/
 
     - name: Get Release File Name & Upload URL

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -156,8 +156,7 @@ jobs:
 
     - name: Package artifact for release
       run: |
-        ls
-        zip -v -r ../${{ matrix.targetPlatform }}.zip -x artifacts/ .* *
+        zip -v -r ../${{ matrix.targetPlatform }}.zip .* *
       working-directory: artifacts/
 
     - name: Get Release File Name & Upload URL

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -145,7 +145,8 @@ jobs:
     - name: Load Release URL File from release job
       uses: actions/download-artifact@v1
       with:
-        name: /tmp/release_url
+        name: release_url
+        path: /tmp/release_url
 
     - name: Download artifact
       uses: actions/download-artifact@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -156,7 +156,7 @@ jobs:
     - name: Package artifact for release
       run: |
         ls
-        zip -r ../${{ matrix.targetPlatform }}.zip -x artifacts/ .* *
+        zip -v -r ../${{ matrix.targetPlatform }}.zip -x artifacts/ .* *
       working-directory: artifacts/
 
     - name: Get Release File Name & Upload URL

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -145,24 +145,25 @@ jobs:
     - name: Load Release URL File from release job
       uses: actions/download-artifact@v1
       with:
-        name: release_url
+        name: /tmp/release_url
 
     - name: Download artifact
       uses: actions/download-artifact@v2
       with:
         name: build-${{ matrix.targetPlatform }}-${{ matrix.unityVersion }}
-        path: artifacts
+        path: artifacts/
 
     - name: Package artifact for release
       run: |
-        zip -r ../${{ matrix.targetPlatform }}.zip .* *
-      working-directory: artifacts
+        ls
+        zip -r ../${{ matrix.targetPlatform }}.zip -x artifacts/ .* *
+      working-directory: artifacts/
 
     - name: Get Release File Name & Upload URL
       id: get_release_info
       run: |
         echo ::set-output name=file_name::${REPOSITORY_NAME##*/}-${TAG_REF_NAME##*/v}
-        value=`cat release_url/release_url.txt`
+        value=`cat /tmp/release_url/release_url.txt`
         echo ::set-output name=upload_url::$value
       env:
         TAG_REF_NAME: ${{ github.ref }}


### PR DESCRIPTION
Remove the `release_url` and `artifacts` resources from release bundles.

These extra files increase the size of the release binaries by a far bit.